### PR TITLE
Quote the comment passed to the user resource

### DIFF
--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -61,7 +61,7 @@ define accounts::user(
   user { $name:
     ensure     => $ensure,
     shell      => $_shell,
-    comment    => $comment,
+    comment    => "${comment}", # lint:ignore:only_variable_string
     home       => $home,
     uid        => $uid,
     gid        => $_gid,


### PR DESCRIPTION
There was a bug affecting puppet 3.7 that was attempting to modified
locked strings when passed to the user type comment field. Work around
this by quoting the variable passed.
