### PR TITLE
(FM-3217) Manage solaris 11 home dirs

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -54,6 +54,12 @@
         "12.04",
         "14.04"
       ]
+    },
+    {
+      "operatingsystem": "Solaris",
+      "operatingsystemrelease": [
+        "11"
+      ]
     }
   ],
   "requirements": [

--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -40,6 +40,21 @@ describe 'accounts::user define', :unless => UNSUPPORTED_PLATFORMS.include?(fact
       it { should be_directory }
     end
   end
+  describe 'warn for sshkeys without managehome' do
+    it 'creates groups of matching names, assigns non-matching group, manages homedir, manages other properties, gives key, makes dotfiles' do
+      pp = <<-EOS
+        accounts::user { 'hunner':
+          managehome => false,
+          sshkeys    => [
+            'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant',
+          ],
+        }
+      EOS
+      apply_manifest(pp, :catch_failures => true) do |r|
+        expect(r.stdout).to match(/Warning:.*ssh keys were passed for user hunner/)
+      end
+    end
+  end
   describe 'locking users' do
     describe user('hunner') do
       it 'locks a user' do

--- a/spec/defines/accounts_user_spec.rb
+++ b/spec/defines/accounts_user_spec.rb
@@ -6,13 +6,37 @@ describe '::accounts::user' do
   let(:facts) { {} }
 
   describe 'expected defaults' do
-    it { is_expected.to contain_user('dan').with({'shell' => '/bin/bash'}) }
-    it { is_expected.to contain_user('dan').with({'home' => "/home/#{title}"}) }
-    it { is_expected.to contain_user('dan').with({'ensure' => 'present'}) }
-    it { is_expected.to contain_user('dan').with({'comment' => title}) }
-    it { is_expected.to contain_user('dan').with({'groups' => []}) }
-    it { is_expected.to contain_group('dan').with({'ensure' => 'present'}) }
-    it { is_expected.to contain_group('dan').with({'gid' => nil}) }
+    it { is_expected.to contain_user('dan').with({'shell'      => '/bin/bash'}) }
+    it { is_expected.to contain_user('dan').with({'home'       => "/home/#{title}"}) }
+    it { is_expected.to contain_user('dan').with({'ensure'     => 'present'}) }
+    it { is_expected.to contain_user('dan').with({'comment'    => title}) }
+    it { is_expected.to contain_user('dan').with({'groups'     => []}) }
+    it { is_expected.to contain_user('dan').with({'managehome' => true }) }
+    it { is_expected.to contain_group('dan').with({'ensure'    => 'present'}) }
+    it { is_expected.to contain_group('dan').with({'gid'       => nil}) }
+  end
+
+  describe 'expected home defaults' do
+    context 'normal user on linux' do
+      let(:title) { "dan" }
+      let(:facts) { { :osfamily => "Debian" } }
+      it { is_expected.to contain_user('dan').with_home('/home/dan') }
+    end
+    context 'root user on linux' do
+      let(:title) { "root" }
+      let(:facts) { { :osfamily => "Debian" } }
+      it { is_expected.to contain_user('root').with_home('/root') }
+    end
+    context 'normal user on Solaris' do
+      let(:title) { "dan" }
+      let(:facts) { { :osfamily => "Solaris" } }
+      it { is_expected.to contain_user('dan').with_home('/export/home/dan') }
+    end
+    context 'root user on Solaris' do
+      let(:title) { "root" }
+      let(:facts) { { :osfamily => "Solaris" } }
+      it { is_expected.to contain_user('root').with_home('/') }
+    end
   end
 
   describe 'when setting user parameters' do
@@ -45,6 +69,7 @@ describe '::accounts::user' do
     it { is_expected.to contain_accounts__home_dir('/var/home/dan').with({'user' => title}) }
     it { is_expected.to contain_accounts__home_dir('/var/home/dan').with({'mode' => '0755'}) }
     it { is_expected.to contain_accounts__home_dir('/var/home/dan').with({'sshkeys' => ['1 2 3', '2 3 4']}) }
+    it { is_expected.to contain_file('/var/home/dan/.ssh') }
 
     describe 'when setting the user to absent' do
 
@@ -73,6 +98,7 @@ describe '::accounts::user' do
         end
 
         it { is_expected.not_to contain_home_dir }
+        it { is_expected.not_to contain_file('/var/home/dan/.ssh') }
       end
     end
   end


### PR DESCRIPTION
Solaris 11 home dirs are mounted at /export/home and are zfs mount
points. This module cannot predict the zpool on which to create the
homedirectory and so leaves it up to `useradd -m`. The zfs mount may
also be pre-created before the accounts resource is run.

Additionally, all resources in the users home directory will not be
managed if managehome is false, but will always be managed if it is true
(ie, no more replace => false)
