### PR TITLE
(maint) Fix failing tests

### DIFF
--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -6,11 +6,13 @@ describe 'accounts::user define', :unless => UNSUPPORTED_PLATFORMS.include?(fact
       it 'creates groups of matching names, assigns non-matching group, manages homedir, manages other properties, gives key, makes dotfiles' do
         pp = <<-EOS
           accounts::user { 'hunner':
-            groups   => ['root'],
-            password => 'hi',
-            shell    => '/bin/true',
-            home     => '/tmp/hunner',
-            sshkeys  => [
+            groups               => ['root'],
+            password             => 'hi',
+            shell                => '/bin/true',
+            home                 => '/tmp/hunner',
+            bashrc_content       => file('accounts/shell/bashrc'),
+            bash_profile_content => file('accounts/shell/bash_profile'),
+            sshkeys              => [
               'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant',
             ],
           }
@@ -51,7 +53,7 @@ describe 'accounts::user define', :unless => UNSUPPORTED_PLATFORMS.include?(fact
         }
       EOS
       apply_manifest(pp, :catch_failures => true) do |r|
-        expect(r.stdout).to match(/Warning:.*ssh keys were passed for user hunner/)
+        expect(r.stderr).to match(/Warning:.*ssh keys were passed for user hunner/)
       end
     end
   end


### PR DESCRIPTION
Tests fail because bashrc & bash_profile are empty,
and warnings come out on stderr not stdout.
