### PR TITLE
(maint) I think selinux context in /tmp doesn't work

### DIFF
--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -5,11 +5,15 @@ describe 'accounts::user define', :unless => UNSUPPORTED_PLATFORMS.include?(fact
     describe user('hunner') do
       it 'creates groups of matching names, assigns non-matching group, manages homedir, manages other properties, gives key, makes dotfiles' do
         pp = <<-EOS
+          file { '/test':
+            ensure => directory,
+            before => Accounts::User['hunner'],
+          }
           accounts::user { 'hunner':
             groups               => ['root'],
             password             => 'hi',
             shell                => '/bin/true',
-            home                 => '/tmp/hunner',
+            home                 => '/test/hunner',
             bashrc_content       => file('accounts/shell/bashrc'),
             bash_profile_content => file('accounts/shell/bash_profile'),
             sshkeys              => [
@@ -23,22 +27,22 @@ describe 'accounts::user define', :unless => UNSUPPORTED_PLATFORMS.include?(fact
       it { should belong_to_group 'hunner' }
       it { should belong_to_group 'root' }
       it { should have_login_shell '/bin/true' }
-      it { should have_home_directory '/tmp/hunner' }
+      it { should have_home_directory '/test/hunner' }
       it { should have_authorized_key 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant' }
     end
-    describe file('/tmp/hunner') do
+    describe file('/test/hunner') do
       it { should be_directory }
       it { should be_mode 700 }
       it { should be_owned_by 'hunner' }
       it { should be_grouped_into 'hunner' }
     end
-    describe file('/tmp/hunner/.bashrc') do
+    describe file('/test/hunner/.bashrc') do
       its(:content) { should match(/managed by Puppet/) }
     end
-    describe file('/tmp/hunner/.bash_profile') do
+    describe file('/test/hunner/.bash_profile') do
       its(:content) { should match(/Get the aliases and functions/) }
     end
-    describe file('/tmp/hunner/.vim') do
+    describe file('/test/hunner/.vim') do
       it { should be_directory }
     end
   end


### PR DESCRIPTION
```
Error: /Stage[main]/Main/Accounts::User[hunner]/User[hunner]/ensure: change from absent to present failed: Could not create user hunner: Execution of '/usr/sbin/useradd -c hunner -g hunner -G root -d /tmp/hunner -p hi -s /bin/true -m hunner' returned 12: useradd: cannot set SELinux context for home directory /tmp/hunner
```
