### PR TITLE
Allow non-managed SSH keys to be purged from user.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -159,6 +159,10 @@ Whether specified groups should be considered the complete list (inclusive) or t
 
 The user's password, in whatever encrypted format the local machine requires. Defaults to '!!', which prevents the user from logging in with a password.
 
+#### `purge_sshkeys`
+
+Whether keys not included in `sshkeys` should be removed from the user. If `purge_sshkeys` is true and `sshkeys` is an empty array, all SSH keys will be removed from the user. Valid values: true, false. Default: false.
+
 #### `shell`
 
 Manages the user shell. Default: '/bin/bash'.

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -20,12 +20,13 @@ define accounts::user(
   $password             = '!!',
   $locked               = false,
   $sshkeys              = [],
+  $purge_sshkeys        = false,
   $managehome           = true,
   $bashrc_content       = undef,
   $bash_profile_content = undef,
 ) {
   validate_re($ensure, '^present$|^absent$')
-  validate_bool($locked, $managehome)
+  validate_bool($locked, $managehome, $purge_sshkeys)
   validate_re($shell, '^/')
   validate_string($comment, $password)
   validate_array($groups, $sshkeys)
@@ -84,16 +85,17 @@ define accounts::user(
   }
 
   user { $name:
-    ensure     => $ensure,
-    shell      => $_shell,
-    comment    => "${comment}", # lint:ignore:only_variable_string
-    home       => $home_real,
-    uid        => $uid,
-    gid        => $_gid,
-    groups     => $groups,
-    membership => $membership,
-    managehome => $managehome,
-    password   => $password,
+    ensure         => $ensure,
+    shell          => $_shell,
+    comment        => "${comment}", # lint:ignore:only_variable_string
+    home           => $home_real,
+    uid            => $uid,
+    gid            => $_gid,
+    groups         => $groups,
+    membership     => $membership,
+    managehome     => $managehome,
+    password       => $password,
+    purge_ssh_keys => $purge_sshkeys,
   }
 
   # use $gid instead of $_gid since `gid` in group can only take a number


### PR DESCRIPTION
Opted name parameter `purge_sshkeys` to match `sshkeys` parameter, although the base user type breaks it up into `purge_ssh_keys`.

If puppetlabs-accounts is to replace pe_accounts, I guess this also touches on [ENTERPRISE-712](https://tickets.puppetlabs.com/browse/ENTERPRISE-712)?