### PR TITLE
Allow duplicate keys to be associated with multiple accounts.

### DIFF
--- a/manifests/home_dir.pp
+++ b/manifests/home_dir.pp
@@ -77,11 +77,15 @@ define accounts::home_dir(
     }
 
     if $sshkeys != [] {
-      accounts::manage_keys { $sshkeys:
-        user     => $user,
-        key_file => $key_file,
-        require  => File["${name}/.ssh"],
-        before   => File[$key_file],
+      $sshkeys.each |String $key| {
+        $key_title = "${user}_${key}"
+        accounts::manage_keys { $key_title:
+          user     => $user,
+          sshkey   => $key,
+          key_file => $key_file,
+          require  => File["${name}/.ssh"],
+          before   => File[$key_file],
+        }
       }
     }
   } elsif $managehome == false {

--- a/manifests/manage_keys.pp
+++ b/manifests/manage_keys.pp
@@ -14,7 +14,6 @@ define accounts::manage_keys(
   ssh_authorized_key { $key_title:
     ensure => present,
     user   => $user,
-    name   => "${user}_${key_name}",
     key    => $key_content,
     type   => $key_type,
     target => $key_file,

--- a/manifests/manage_keys.pp
+++ b/manifests/manage_keys.pp
@@ -1,10 +1,11 @@
 #
 define accounts::manage_keys(
   $user,
+  $sshkey,
   $key_file,
 ) {
 
-  $key_array   = split($name, ' ')
+  $key_array   = split($sshkey, ' ')
   $key_type    = $key_array[0]
   $key_content = $key_array[1]
   $key_name    = $key_array[2]
@@ -13,7 +14,7 @@ define accounts::manage_keys(
   ssh_authorized_key { $key_title:
     ensure => present,
     user   => $user,
-    name   => $key_name,
+    name   => "${user}_${key_name}",
     key    => $key_content,
     type   => $key_type,
     target => $key_file,


### PR DESCRIPTION
Because `accounts::manage_keys`` uses the entire key as the namevar it causes duplicate resource declarations if the same key is used on multiple users on the same node.

This PR attempts to enforce unique accounts::manage_keys and ssh_authorized_keys by prepending the sshkey name with the user it's being associated with. Running this version after applying previous versions of accounts::user may result in duplicate keys, but with different names.