### PR TITLE
Github Issue #50: accounts::group class does not exist

### DIFF
--- a/examples/user_group.pp
+++ b/examples/user_group.pp
@@ -1,17 +1,17 @@
 accounts::group { 'admin':
-  gid => 3000,
+  gid => '3000',
 }
 accounts::group { 'sudo':
-  gid => 3001,
+  gid => '3001',
 }
 accounts::group { 'sudonopw':
-  gid => 3002,
+  gid => '3002',
 }
 accounts::group { 'developer':
-  gid => 3003,
+  gid => '3003',
 }
 accounts::group { 'ops':
-  gid => 3004,
+  gid => '3004',
 }
 
 accounts::user { 'jeff':
@@ -21,8 +21,8 @@ accounts::user { 'jeff':
     'admin',
     'sudonopw',
   ],
-  uid      => 1112,
-  gid      => 1112,
+  uid      => '1112',
+  gid      => '1112',
   locked   => true,
   sshkeys  => [
     'ssh-rsa AAAA...',

--- a/manifests/group.pp
+++ b/manifests/group.pp
@@ -1,0 +1,18 @@
+define accounts::group(
+  $ensure               = 'present',
+  $gid                  = undef,
+) {
+  validate_re($ensure, '^(present|absent)$')
+
+  if $gid != undef {
+    validate_re($gid, '^\d+$')
+    $_gid = $gid
+  } else {
+    $_gid = $name
+  }
+
+  group { $name:
+    ensure => $ensure,
+    gid    => $_gid,
+  }
+}


### PR DESCRIPTION
When using puppetlabs/puppetlabs-accounts the example files provide "templates" for using the class and adding a user and groups.

If you follow the current examples they will fail for two reasons:
- accounts::group does not exist
- the examples include non-quoted variables which fail the validate_re checks

I have added manifests/group.pp to address the missing class and updated the example files to quote the gid so that validate_re treats it as a string.

I've tested locally and this fixes the issue for me and I have successfully added a user and a separate group with this module now.

I haven't updated the spec tests as I am not that familiar with that part of Puppet (yet). :D

I believe this PR will also fix https://tickets.puppetlabs.com/browse/MODULES-3114

Any questions let me know!

Cheers,

Amo
@sysadmiral
