### PR TITLE
Feature: manage primary group creation. See  MODULES-3440

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -122,7 +122,7 @@ A comment describing or regarding the user. Accepts a string. Default: '$name'.
 
 #### `ensure`
 
-Specifies whether the user, its primary group, homedir, and ssh keys should exist. Valid values are 'present' and 'absent'. Note that when a user is created, a group with the same name as the user is also created. Default: 'present'.
+Specifies whether the user, its primary group, homedir, and ssh keys should exist. Valid values are 'present' and 'absent'. Note that when a user is created, a group with the same name as the user is also created, unless you set manage_primary_group to false. Default: 'present'.
 
 #### `gid`
 
@@ -131,6 +131,10 @@ Specifies the gid of the user's primary group. Must be specified numerically. De
 #### `groups`
 
 Specifies the user's group memberships. Valid values: an array. Default: an empty array.
+
+#### `manage_primary_group`
+
+Manage the primary group. Default: true
 
 #### `home`
 

--- a/manifests/home_dir.pp
+++ b/manifests/home_dir.pp
@@ -13,6 +13,7 @@ define accounts::home_dir(
   $ensure               = 'present',
   $managehome           = true,
   $sshkeys              = [],
+  $group                = $user,
 ) {
   validate_re($ensure, '^(present|absent)$')
 
@@ -32,21 +33,21 @@ define accounts::home_dir(
     file { $name:
       ensure => directory,
       owner  => $user,
-      group  => $user,
+      group  => $group,
       mode   => $mode,
     }
 
     file { "${name}/.ssh":
       ensure => directory,
       owner  => $user,
-      group  => $user,
+      group  => $group,
       mode   => '0700',
     }
 
     file { "${name}/.vim":
       ensure => directory,
       owner  => $user,
-      group  => $user,
+      group  => $group,
       mode   => '0700',
     }
 
@@ -55,7 +56,7 @@ define accounts::home_dir(
         ensure  => file,
         content => $bashrc_content,
         owner   => $user,
-        group   => $user,
+        group   => $group,
         mode    => '0644',
       }
     }
@@ -64,7 +65,7 @@ define accounts::home_dir(
         ensure  => file,
         content => $bash_profile_content,
         owner   => $user,
-        group   => $user,
+        group   => $group,
         mode    => '0644',
       }
     }
@@ -72,7 +73,7 @@ define accounts::home_dir(
     file { $key_file:
       ensure => file,
       owner  => $user,
-      group  => $user,
+      group  => $group,
       mode   => '0600',
     }
 

--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -62,6 +62,28 @@ describe 'accounts::user define', :unless => UNSUPPORTED_PLATFORMS.include?(fact
       end
     end
   end
+  describe 'create user myuser without managing the primary group, group mygroup with id 666 exists' do
+    describe user('myuser') do
+      it 'does not create group myuser' do
+        pp = <<-EOS
+          group {
+            'somegroup':
+              ensure => present,
+              gid    => 666;
+          }
+
+          accounts::user { 'myuser':
+            gid                  => 666,
+            manage_primary_group => false,
+          }
+        EOS
+        apply_manifest(pp, :catch_failures => true)
+      end
+      it { should exist }
+      it { should_not belong_to_group 'myuser' }
+      it { should belong_to_primary_group 'somegroup' }
+    end
+  end
   describe 'locking users' do
     describe user('hunner') do
       it 'locks a user' do

--- a/spec/defines/accounts_user_spec.rb
+++ b/spec/defines/accounts_user_spec.rb
@@ -71,6 +71,14 @@ describe '::accounts::user' do
     it { is_expected.to contain_accounts__home_dir('/var/home/dan').with({'sshkeys' => ['1 2 3', '2 3 4']}) }
     it { is_expected.to contain_file('/var/home/dan/.ssh') }
 
+    describe 'when setting manage_primary_group to false' do
+      before do
+        params['manage_primary_group'] = false
+      end
+
+      it { is_expected.not_to contain_group('dan') }
+    end
+
     describe 'when setting the user to absent' do
 
       # when deleting users the home dir is a File resource instead of a accounts::home_dir
@@ -120,6 +128,10 @@ describe '::accounts::user' do
     end
     it 'should fail if gid is not composed of digits' do
       params['gid'] = 'name'
+      expect { subject.call }.to raise_error Puppet::Error
+    end
+    it 'should not accept non-boolean values for manange_primary_group' do
+      params['manage_primary_group'] = 'false'
       expect { subject.call }.to raise_error Puppet::Error
     end
     it 'should not accept non-boolean values for locked' do


### PR DESCRIPTION
Currently passing the gid parameter to accounts::user creates a new group on the system with the same name as the user. As default behavior this is good.
However I would like it to be possible to set the gid to a group that is already on the system. (E.g. the 'users' group).
