### PR TITLE
Allow the use of the `source` param for bash files.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -110,11 +110,19 @@ This resource manages the user, group, .vim/, .ssh/, .bash\_profile, .bashrc, ho
 
 #### `bashrc_content`
 
-The content to place in the user's ~/.bashrc file. Default: undef.
+The content to place in the user's ~/.bashrc file. Mutually exclusive to `bashrc_source`. Default: undef.
+
+#### `bashrc_source`
+
+A source file containing the content to place in the user's ~/.bashrc file. Mutually exclusive to `bashrc_content`. Default: undef.
 
 #### `bash_profile_content`
 
-The content to place in the user's ~/.bash\_profile file. Default: undef.
+The content to place in the user's ~/.bash\_profile file. Mutually exclusive to `bash_profile_source`. Default: undef.
+
+#### `bash_profile_source`
+
+A source file containing the content to place in the user's ~/.bash\_profile file. Mutually exclusive to `bash_profile_content`. Default: undef.
 
 #### `comment`
 

--- a/manifests/home_dir.pp
+++ b/manifests/home_dir.pp
@@ -8,7 +8,9 @@
 define accounts::home_dir(
   $user,
   $bashrc_content       = undef,
+  $bashrc_source        = undef,
   $bash_profile_content = undef,
+  $bash_profile_source  = undef,
   $mode                 = '0700',
   $ensure               = 'present',
   $managehome           = true,
@@ -50,22 +52,40 @@ define accounts::home_dir(
       mode   => '0700',
     }
 
-    if $bashrc_content {
+    if $bashrc_content or $bashrc_source {
       file { "${name}/.bashrc":
-        ensure  => file,
-        content => $bashrc_content,
-        owner   => $user,
-        group   => $user,
-        mode    => '0644',
+        ensure => file,
+        owner  => $user,
+        group  => $user,
+        mode   => '0644',
+      }
+      if $bashrc_content {
+        File["${name}/.bashrc"] {
+          content => $bashrc_content,
+        }
+      }
+      if $bashrc_source {
+        File["${name}/.bashrc"] {
+          source => $bashrc_source,
+        }
       }
     }
-    if $bash_profile_content {
+    if $bash_profile_content or $bash_profile_source {
       file { "${name}/.bash_profile":
-        ensure  => file,
-        content => $bash_profile_content,
-        owner   => $user,
-        group   => $user,
-        mode    => '0644',
+        ensure => file,
+        owner  => $user,
+        group  => $user,
+        mode   => '0644',
+      }
+      if $bash_profile_content {
+        File["${name}/.bash_profile"] {
+          content => $bash_profile_content,
+        }
+      }
+      if $bash_profile_source {
+        File["${name}/.bash_profile"] {
+          source => $bash_profile_source,
+        }
       }
     }
 

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -23,7 +23,9 @@ define accounts::user(
   $purge_sshkeys        = false,
   $managehome           = true,
   $bashrc_content       = undef,
+  $bashrc_source        = undef,
   $bash_profile_content = undef,
+  $bash_profile_source  = undef,
 ) {
   validate_re($ensure, '^present$|^absent$')
   validate_bool($locked, $managehome, $purge_sshkeys)
@@ -34,8 +36,14 @@ define accounts::user(
   if $bashrc_content {
     validate_string($bashrc_content)
   }
+  if $bashrc_source {
+    validate_string($bashrc_source)
+  }
   if $bash_profile_content {
     validate_string($bash_profile_content)
+  }
+  if $bash_profile_source {
+    validate_string($bash_profile_source)
   }
   if $home {
     validate_re($home, '^/')
@@ -115,7 +123,9 @@ define accounts::user(
     mode                 => $home_mode,
     managehome           => $managehome,
     bashrc_content       => $bashrc_content,
+    bashrc_source        => $bashrc_source,
     bash_profile_content => $bash_profile_content,
+    bash_profile_source  => $bash_profile_source,
     user                 => $name,
     sshkeys              => $sshkeys,
     require              => [ User[$name], Group[$name] ],


### PR DESCRIPTION
This makes the module easier to manage with Hiera and Automatic Parameter Lookup
by being able to simply put the file server URI for your bashrc and bash_profile
in Hiera instead of wrapping it to fetch the content with a file() function.