### PR TITLE
Revert "Allow duplicate keys to be associated with multiple accounts."

### DIFF
--- a/manifests/home_dir.pp
+++ b/manifests/home_dir.pp
@@ -77,15 +77,11 @@ define accounts::home_dir(
     }
 
     if $sshkeys != [] {
-      $sshkeys.each |String $key| {
-        $key_title = "${user}_${key}"
-        accounts::manage_keys { $key_title:
-          user     => $user,
-          sshkey   => $key,
-          key_file => $key_file,
-          require  => File["${name}/.ssh"],
-          before   => File[$key_file],
-        }
+      accounts::manage_keys { $sshkeys:
+        user     => $user,
+        key_file => $key_file,
+        require  => File["${name}/.ssh"],
+        before   => File[$key_file],
       }
     }
   } elsif $managehome == false {

--- a/manifests/manage_keys.pp
+++ b/manifests/manage_keys.pp
@@ -1,11 +1,10 @@
 #
 define accounts::manage_keys(
   $user,
-  $sshkey,
   $key_file,
 ) {
 
-  $key_array   = split($sshkey, ' ')
+  $key_array   = split($name, ' ')
   $key_type    = $key_array[0]
   $key_content = $key_array[1]
   $key_name    = $key_array[2]
@@ -14,6 +13,7 @@ define accounts::manage_keys(
   ssh_authorized_key { $key_title:
     ensure => present,
     user   => $user,
+    name   => $key_name,
     key    => $key_content,
     type   => $key_type,
     target => $key_file,


### PR DESCRIPTION
Reverts puppetlabs/puppetlabs-accounts#54

This PR fails on Puppet 3.8.7 and was created before those jobs were added to Travis.