### PR TITLE
Group name

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,12 +30,7 @@ end
 # Used for gem conditionals
 supports_windows = false
 ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
-minor_version_tmp = "#{ruby_version_segments[0]}.#{ruby_version_segments[1]}"
-if minor_version_tmp.to_f > 2.3
-  minor_version = "2.3"
-else
-  minor_version = minor_version_tmp
-end
+minor_version = "#{ruby_version_segments[0]}.#{ruby_version_segments[1]}"
 
 group :development do
   gem "puppet-module-posix-default-r#{minor_version}", :require => false, :platforms => "ruby"

--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,12 @@ end
 # Used for gem conditionals
 supports_windows = false
 ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
-minor_version = "#{ruby_version_segments[0]}.#{ruby_version_segments[1]}"
+minor_version_tmp = "#{ruby_version_segments[0]}.#{ruby_version_segments[1]}"
+if minor_version_tmp.to_f > 2.3
+  minor_version = "2.3"
+else
+  minor_version = minor_version_tmp
+end
 
 group :development do
   gem "puppet-module-posix-default-r#{minor_version}", :require => false, :platforms => "ruby"

--- a/README.markdown
+++ b/README.markdown
@@ -106,7 +106,7 @@ accounts::user { 'jeff':
 
 ### Defined type: `accounts::user`
 
-This resource manages the user, group, .ssh/, .bash\_profile, .bashrc, homedir, .ssh/authorized\_keys files, and directories.
+This resource manages the user, group, vim/, .ssh/, .bash\_profile, .bashrc, homedir, .ssh/authorized\_keys files, and directories.
 
 #### `bashrc_content`
 

--- a/README.markdown
+++ b/README.markdown
@@ -42,6 +42,7 @@ The above example creates accounts, home directories, and groups for Dan and Mor
 accounts::user { 'bob':
   uid      => '4001',
   gid      => '4001',
+  group    => 'staff',
   shell    => '/bin/bash',
   password => '!!',
   locked   => false,
@@ -105,7 +106,7 @@ accounts::user { 'jeff':
 
 ### Defined type: `accounts::user`
 
-This resource manages the user, group, .vim/, .ssh/, .bash\_profile, .bashrc, homedir, .ssh/authorized\_keys files, and directories.
+This resource manages the user, group, .ssh/, .bash\_profile, .bashrc, homedir, .ssh/authorized\_keys files, and directories.
 
 #### `bashrc_content`
 
@@ -134,6 +135,10 @@ Specifies whether the user, its primary group, homedir, and ssh keys should exis
 #### `gid`
 
 Specifies the gid of the user's primary group. Must be specified numerically. Default: undef.
+
+#### `group`
+
+Specifies the name of the user's primary group. Must be specified as a string. Default: a group named the same as user name
 
 #### `groups`
 

--- a/examples/group_common.pp
+++ b/examples/group_common.pp
@@ -1,0 +1,23 @@
+# Use a variable OR with hiera_hash():
+# This example uses a common group name for both users
+
+$users_hash = {
+  'jblow' => {
+    'comment'  => 'Joe Blow',
+    'groups'   => [ wheel ],
+    'uid'      => '1115',
+    'gid'      => '1115',
+    'group'    => 'mrblow',
+    'sshkeys'  => [
+      'ssh-rsa AAAAB3Nza...== jblow@puppetlabs.com',
+      'ssh-dss AAAAB3Nza...== jblow@googler.net',
+    ],
+    'password' => '!!',
+  },
+  'kblow' => {
+    'comment'  => 'Ken Blow',
+    'group'    => 'mrblow',
+    'password' => '!!',
+  },
+}
+create_resources('accounts::user', $users_hash)

--- a/examples/user_group.pp
+++ b/examples/user_group.pp
@@ -1,16 +1,16 @@
-accounts::group { 'admin':
+group { 'admin':
   gid => 3000,
 }
-accounts::group { 'sudo':
+group { 'sudo':
   gid => 3001,
 }
-accounts::group { 'sudonopw':
+group { 'sudonopw':
   gid => 3002,
 }
-accounts::group { 'developer':
+group { 'developer':
   gid => 3003,
 }
-accounts::group { 'ops':
+group { 'ops':
   gid => 3004,
 }
 
@@ -25,8 +25,8 @@ accounts::user { 'jeff':
   gid      => 1112,
   locked   => true,
   sshkeys  => [
-    'ssh-rsa AAAA...',
-    'ssh-dss AAAA...',
+    'ssh-rsa AAAAB3Nza...== jeff@puppetlabs.com',
+    'ssh-dss AAAAB3Nza...== jeff@metamachine.net',
   ],
   password => '!!',
 }

--- a/examples/user_group_hash.pp
+++ b/examples/user_group_hash.pp
@@ -6,7 +6,7 @@ $groups_hash = {
   'developer' => { gid => '3003' },
   'ops'       => { gid => '3004' },
 }
-create_resources('accounts::group', $groups_hash)
+create_resources('group', $groups_hash)
 
 $users_hash = {
   'jeff' => {
@@ -17,8 +17,8 @@ $users_hash = {
     'gid'      => '1112',
     'locked'   => true,
     'sshkeys'  => [
-      'ssh-rsa AAAA...',
-      'ssh-dss AAAA...',
+      'ssh-rsa AAAAB3Nza...== jeff@puppetlabs.com',
+      'ssh-dss AAAAB3Nza...== jeff@metamachine.net',
     ],
     'password' => '!!',
   },

--- a/manifests/home_dir.pp
+++ b/manifests/home_dir.pp
@@ -47,6 +47,13 @@ define accounts::home_dir(
       mode   => '0700',
     }
 
+    file { "${name}/.vim":
+      ensure => directory,
+      owner  => $user,
+      group  => $group,
+      mode   => '0700',
+    }
+
     if $bashrc_content or $bashrc_source {
       file { "${name}/.bashrc":
         ensure => file,

--- a/manifests/home_dir.pp
+++ b/manifests/home_dir.pp
@@ -2,11 +2,13 @@
 # Specified how home directories are managed.
 #
 # [*name*] Name of the home directory that is being managed.
+# [*group*] Name of the users primary group
 # [*user*] User that owns all of the files being created.
 # [*sshkeys*] List of ssh keys to be added for this user in this
 # directory
 define accounts::home_dir(
   $user,
+  $group,
   $bashrc_content       = undef,
   $bashrc_source        = undef,
   $bash_profile_content = undef,
@@ -34,21 +36,14 @@ define accounts::home_dir(
     file { $name:
       ensure => directory,
       owner  => $user,
-      group  => $user,
+      group  => $group,
       mode   => $mode,
     }
 
     file { "${name}/.ssh":
       ensure => directory,
       owner  => $user,
-      group  => $user,
-      mode   => '0700',
-    }
-
-    file { "${name}/.vim":
-      ensure => directory,
-      owner  => $user,
-      group  => $user,
+      group  => $group,
       mode   => '0700',
     }
 
@@ -56,7 +51,7 @@ define accounts::home_dir(
       file { "${name}/.bashrc":
         ensure => file,
         owner  => $user,
-        group  => $user,
+        group  => $group,
         mode   => '0644',
       }
       if $bashrc_content {
@@ -74,7 +69,7 @@ define accounts::home_dir(
       file { "${name}/.bash_profile":
         ensure => file,
         owner  => $user,
-        group  => $user,
+        group  => $group,
         mode   => '0644',
       }
       if $bash_profile_content {
@@ -92,7 +87,7 @@ define accounts::home_dir(
     file { $key_file:
       ensure => file,
       owner  => $user,
-      group  => $user,
+      group  => $group,
       mode   => '0600',
     }
 

--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -84,4 +84,31 @@ describe 'accounts::user define', :unless => UNSUPPORTED_PLATFORMS.include?(fact
       }
     end
   end
+  describe 'create user with custom group name' do
+    describe user('cuser') do
+      it 'creates group of matching names, assigns non-matching group, manages homedir' do
+        pp = <<-EOS
+          file { '/test':
+            ensure => directory,
+            before => Accounts::User['cuser'],
+          }
+          accounts::user { 'cuser':
+            group                => 'staff',
+            password             => '!!',
+            home                 => '/test/cuser',
+          }
+        EOS
+        apply_manifest(pp, :catch_failures => true)
+      end
+      it { should exist }
+      it { should belong_to_group 'staff' }
+      it { should have_home_directory '/test/cuser' }
+    end
+    describe file('/test/cuser') do
+      it { should be_directory }
+      it { should be_mode 700 }
+      it { should be_owned_by 'cuser' }
+      it { should be_grouped_into 'staff' }
+    end
+  end
 end

--- a/spec/defines/accounts_user_spec.rb
+++ b/spec/defines/accounts_user_spec.rb
@@ -11,6 +11,7 @@ describe '::accounts::user' do
     it { is_expected.to contain_user('dan').with({'home'       => "/home/#{title}"}) }
     it { is_expected.to contain_user('dan').with({'ensure'     => 'present'}) }
     it { is_expected.to contain_user('dan').with({'comment'    => title}) }
+    it { is_expected.to contain_user('dan').with({'group'      => title}) }
     it { is_expected.to contain_user('dan').with({'groups'     => []}) }
     it { is_expected.to contain_user('dan').with({'managehome' => true }) }
     it { is_expected.to contain_group('dan').with({'ensure'    => 'present'}) }
@@ -49,6 +50,7 @@ describe '::accounts::user' do
       params['home_mode']  = '0755'
       params['uid']        = '123'
       params['gid']        = '456'
+      params['group']      = 'dan'
       params['groups']     = ['admin']
       params['membership'] = 'inclusive'
       params['password']   = 'foo'
@@ -61,6 +63,7 @@ describe '::accounts::user' do
     it { is_expected.to contain_user('dan').with({'home' => '/var/home/dan'}) }
     it { is_expected.to contain_user('dan').with({'uid' => '123'}) }
     it { is_expected.to contain_user('dan').with({'gid' => '456'}) }
+    it { is_expected.to contain_user('dan').with({'group' => 'dan'}) }
     it { is_expected.to contain_user('dan').with({'groups' => ['admin']}) }
     it { is_expected.to contain_user('dan').with({'membership' => 'inclusive'}) }
     it { is_expected.to contain_user('dan').with({'password' => 'foo'}) }

--- a/spec/defines/accounts_user_spec.rb
+++ b/spec/defines/accounts_user_spec.rb
@@ -11,7 +11,7 @@ describe '::accounts::user' do
     it { is_expected.to contain_user('dan').with({'home'       => "/home/#{title}"}) }
     it { is_expected.to contain_user('dan').with({'ensure'     => 'present'}) }
     it { is_expected.to contain_user('dan').with({'comment'    => title}) }
-    it { is_expected.to contain_user('dan').with({'group'      => title}) }
+    it { is_expected.to contain_user('dan').with({'gid'        => title}) }
     it { is_expected.to contain_user('dan').with({'groups'     => []}) }
     it { is_expected.to contain_user('dan').with({'managehome' => true }) }
     it { is_expected.to contain_group('dan').with({'ensure'    => 'present'}) }
@@ -62,8 +62,7 @@ describe '::accounts::user' do
     it { is_expected.to contain_user('dan').with({'comment' => 'comment'}) }
     it { is_expected.to contain_user('dan').with({'home' => '/var/home/dan'}) }
     it { is_expected.to contain_user('dan').with({'uid' => '123'}) }
-    it { is_expected.to contain_user('dan').with({'gid' => '456'}) }
-    it { is_expected.to contain_user('dan').with({'group' => 'dan'}) }
+    it { is_expected.to contain_user('dan').with({'gid' => 'dan'}) }
     it { is_expected.to contain_user('dan').with({'groups' => ['admin']}) }
     it { is_expected.to contain_user('dan').with({'membership' => 'inclusive'}) }
     it { is_expected.to contain_user('dan').with({'password' => 'foo'}) }


### PR DESCRIPTION
This PR allows for an account to be created with a custom primary group name that does not match the user name that could be used for multiple users such as 'staff' or 'users'.

Specifying the GID is still valid, along with the group name and this PR also handles group removal if the group name matches the user name only.

Additional examples provided, along with bug fixes for existing examples.
