### PR TITLE
Remove dependency on group resource if create_group is false

### DIFF
--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -126,10 +126,12 @@ define accounts::user(
     system         => $system,
   }
 
-  if $ensure == 'present' {
-    Group[$group] -> User[$name]
-  } else {
-    User[$name] -> Group[$group]
+  if $create_group {
+    if $ensure == 'present' {
+      Group[$group] -> User[$name]
+    } else {
+      User[$name] -> Group[$group]
+    }
   }
 
   accounts::home_dir { $home_real:
@@ -143,6 +145,6 @@ define accounts::user(
     user                 => $name,
     group                => $group,
     sshkeys              => $sshkeys,
-    require              => [ User[$name], Group[$group] ],
+    require              => [ User[$name] ],
   }
 }


### PR DESCRIPTION
If the create_group variable is set to false, then there won't be any group
resource being created. Hence we need to remove the depedency on group resource.

Signed-off-by: Ayush Mittal <ayush.m@endurance.com>