### PR TITLE
(maint) - Removing Ubuntu 12.04

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -56,7 +56,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "12.04",
         "14.04",
         "16.04"
       ]


### PR DESCRIPTION
Ubuntu 12.04 became end of life in April. Removing from our supported
operating systems.