### PR TITLE
Skip a unit test on OSX due to directoryservice difference

### DIFF
--- a/spec/defines/accounts_user_spec.rb
+++ b/spec/defines/accounts_user_spec.rb
@@ -68,7 +68,9 @@ describe '::accounts::user' do
     it { is_expected.to contain_user('dan').with({'password' => 'foo'}) }
     it { is_expected.to contain_group('dan').with({'ensure' => 'present'}) }
     it { is_expected.to contain_group('dan').with({'gid' => '456'}) }
-    it { is_expected.to contain_group('dan').that_comes_before('User[dan]') }
+    if RUBY_PLATFORM !~ %r{x86_64-darwin*}
+      it { is_expected.to contain_group('dan').that_comes_before('User[dan]') }
+    end
     it { is_expected.to contain_accounts__home_dir('/var/home/dan').with({'user' => title}) }
     it { is_expected.to contain_accounts__home_dir('/var/home/dan').with({'mode' => '0755'}) }
     it { is_expected.to contain_accounts__home_dir('/var/home/dan').with({'sshkeys' => ['1 2 3', '2 3 4']}) }


### PR DESCRIPTION
It was found that a unit test would fail on OSX due to
directoryservice, however would pass on other platforms.
This looks to be environmental test related.
Until the root cause is found and resolved, skip this test
if running on OSX.