### PR TITLE
(MODULES-5778) Set operatingsystem fact in specs

### DIFF
--- a/spec/defines/accounts_user_spec.rb
+++ b/spec/defines/accounts_user_spec.rb
@@ -6,7 +6,13 @@ describe '::accounts::user' do
   let(:facts) { {} }
 
   describe 'expected defaults' do
-    let(:facts) { { :osfamily => "Debian" } }
+    let(:facts) do
+      {
+        :osfamily        => "Debian",
+        :operatingsystem => 'Debian',
+      }
+    end
+
     it { is_expected.to contain_user('dan').with({'shell'      => '/bin/bash'}) }
     it { is_expected.to contain_user('dan').with({'home'       => "/home/#{title}"}) }
     it { is_expected.to contain_user('dan').with({'ensure'     => 'present'}) }
@@ -21,27 +27,58 @@ describe '::accounts::user' do
   describe 'expected home defaults' do
     context 'normal user on linux' do
       let(:title) { "dan" }
-      let(:facts) { { :osfamily => "Debian" } }
+      let(:facts) do
+        {
+          :osfamily        => "Debian",
+          :operatingsystem => 'Debian',
+        }
+      end
+
       it { is_expected.to contain_user('dan').with_home('/home/dan') }
     end
     context 'root user on linux' do
       let(:title) { "root" }
-      let(:facts) { { :osfamily => "Debian" } }
+      let(:facts) do
+        {
+          :osfamily        => "Debian",
+          :operatingsystem => 'Debian',
+        }
+      end
+
       it { is_expected.to contain_user('root').with_home('/root') }
     end
     context 'normal user on Solaris' do
       let(:title) { "dan" }
-      let(:facts) { { :osfamily => "Solaris" } }
+      let(:facts) do
+        {
+          :osfamily        => "Solaris",
+          :operatingsystem => 'Solaris',
+        }
+      end
+
       it { is_expected.to contain_user('dan').with_home('/export/home/dan') }
     end
     context 'root user on Solaris' do
       let(:title) { "root" }
-      let(:facts) { { :osfamily => "Solaris" } }
+      let(:facts) do
+        {
+          :osfamily        => "Solaris",
+          :operatingsystem => 'Solaris',
+        }
+      end
+
       it { is_expected.to contain_user('root').with_home('/') }
     end
   end
 
   describe 'when setting user parameters' do
+    let(:facts) do
+      {
+        :osfamily        => "Debian",
+        :operatingsystem => 'Debian',
+      }
+    end
+
     before do
       params['ensure']     = 'present'
       params['shell']      = '/bin/csh'


### PR DESCRIPTION
Most of the User providers confine based on the `operatingsystem` fact,
so this needs to be set in order for rspec-puppet to properly fake out
the platform.

Long term, it would be best to convert this module's tests over to using
rspec-puppet-facts & facterdb, that way you don't need to worry about
which facts you need to set as you'll get a full set for each supported
OS.

/cc @willmeek @eputnam 