### PR TITLE
Skips password check test on Solaris

### DIFF
--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -28,7 +28,8 @@ describe 'accounts::user define', :unless => UNSUPPORTED_PLATFORMS.include?(fact
       it { should belong_to_group 'root' }
       it { should have_login_shell '/bin/true' }
       it { should have_home_directory '/test/hunner' }
-      it { should contain_password 'hi' }
+      # Solaris does not offer a means of testing the password
+      it("should contain password", :unless => default['platform'].match(/solaris/)) { should contain_password 'hi' }
       # Solaris 10's /bin/sh can't expand ~username paths and thus can't read ~hunner/.ssh/authorized_keys
       it("should have authorized_key", :unless => default['platform'].match(/solaris-10/)) { should have_authorized_key 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant' }
     end
@@ -112,7 +113,8 @@ describe 'accounts::user define', :unless => UNSUPPORTED_PLATFORMS.include?(fact
       it { should be_grouped_into 'staff' }
     end
   end
-  describe 'ignore password if ignore set to true' do
+  # Solaris does not offer a means of testing the password
+  describe 'ignore password if ignore set to true', :unless => default['platform'].match(/solaris/) do
     describe user('ignore_user') do
       it 'creates group of matching names, assigns non-matching group, empty password, ignore true, ignores password' do
         pp = <<-EOS
@@ -143,7 +145,8 @@ describe 'accounts::user define', :unless => UNSUPPORTED_PLATFORMS.include?(fact
       it { should contain_password 'foo' }
     end
   end
-  describe 'do not ignore password if ignore set to false' do
+  # Solaris does not offer a means of testing the password
+  describe 'do not ignore password if ignore set to false', :unless => default['platform'].match(/solaris/) do
     describe user('no_ignore_user') do
       it 'creates group of matching names, assigns non-matching group, empty password, ignore false, should not ignore password' do
         pp = <<-EOS
@@ -174,7 +177,7 @@ describe 'accounts::user define', :unless => UNSUPPORTED_PLATFORMS.include?(fact
       it { should contain_password '' }
     end
   end
-  describe 'do not ignore password if set and ignore set to true' do
+  describe 'do not ignore password if set and ignore set to true', :unless => default['platform'].match(/solaris/) do
     describe user('specd_user') do
       it 'creates group of matching names, assigns non-matching group, specify password, ignore, should not ignore password' do
         pp = <<-EOS


### PR DESCRIPTION
Solaris does not allow access to a user unencrypted password.
This commit skips those tests when ran on Solaris.