### PR TITLE
Don't create accounts::home_dir resources

### DIFF
--- a/manifests/home_dir.pp
+++ b/manifests/home_dir.pp
@@ -17,18 +17,17 @@ define accounts::home_dir(
   $forward_source       = undef,
   $mode                 = '0700',
   $ensure               = 'present',
-  $managehome           = true,
   $sshkeys              = [],
 ) {
   validate_re($ensure, '^(present|absent)$')
 
-  if $ensure == 'absent' and $managehome == true {
+  if $ensure == 'absent' {
     file { $name:
       ensure  => absent,
       recurse => true,
       force   => true,
     }
-  } elsif $ensure == 'present' and $managehome == true {
+  } elsif $ensure == 'present' {
 
     $key_file = "${name}/.ssh/authorized_keys"
 
@@ -126,10 +125,6 @@ define accounts::home_dir(
         require  => File["${name}/.ssh"],
         before   => File[$key_file],
       }
-    }
-  } elsif $managehome == false {
-    if $sshkeys != [] {
-      warning("ssh keys were passed for user ${user} but \$managehome is set to false; not managing user ssh keys")
     }
   }
 }

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -159,19 +159,22 @@ define accounts::user(
     }
   }
 
-  accounts::home_dir { $home_real:
-    ensure               => $ensure,
-    mode                 => $home_mode,
-    managehome           => $managehome,
-    bashrc_content       => $bashrc_content,
-    bashrc_source        => $bashrc_source,
-    bash_profile_content => $bash_profile_content,
-    bash_profile_source  => $bash_profile_source,
-    forward_content      => $forward_content,
-    forward_source       => $forward_source,
-    user                 => $name,
-    group                => $group,
-    sshkeys              => $sshkeys,
-    require              => [ User[$name] ],
+  if $managehome {
+    accounts::home_dir { $home_real:
+      ensure               => $ensure,
+      mode                 => $home_mode,
+      bashrc_content       => $bashrc_content,
+      bashrc_source        => $bashrc_source,
+      bash_profile_content => $bash_profile_content,
+      bash_profile_source  => $bash_profile_source,
+      forward_content      => $forward_content,
+      forward_source       => $forward_source,
+      user                 => $name,
+      group                => $group,
+      sshkeys              => $sshkeys,
+      require              => [ User[$name] ],
+    }
+  } elsif $sshkeys != [] {
+      warning("ssh keys were passed for user ${name} but \$managehome is set to false; not managing user ssh keys")
   }
 }


### PR DESCRIPTION
Even with managehome set to false, `accounts::home_dir` resources need to be unique, implying all managed users should have a unique homedir. On default CentOS (and probably others) installs some system users share `/` as homedir.

Don't create a `accounts::home_dir` resource when managehome
is set to false.