### PR TITLE
Allow mode for homedir to be undef

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -173,7 +173,7 @@ Default:
 
 #### `home_mode`
 
-Manages the user's home directory permission mode. Valid values are in [octal notation](https://docs.puppetlabs.com/references/latest/type.html#file-attribute-mode), specified as a string. Defaults to `0700`, which gives the owner full read, write, and execute permissions, while group and other have no permissions.
+Manages the user's home directory permission mode. Valid values are in [octal notation](https://docs.puppetlabs.com/references/latest/type.html#file-attribute-mode), specified as a string. Defaults to `undef`, which will create a home directory with `0700` permissions but will not touch them if the directory already exists. Keeping it `undef` also allows a user to manage their own permissions, if `home_mode` is set, puppet will enfore the permissions on every run.
 
 #### `locked`
 

--- a/manifests/home_dir.pp
+++ b/manifests/home_dir.pp
@@ -15,7 +15,7 @@ define accounts::home_dir(
   $bash_profile_source  = undef,
   $forward_content      = undef,
   $forward_source       = undef,
-  $mode                 = '0700',
+  $mode                 = undef,
   $ensure               = 'present',
   $sshkeys              = [],
 ) {

--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -14,6 +14,7 @@ pp_accounts_define = <<-PUPPETCODE
             password             => 'hi',
             shell                => '/bin/true',
             home                 => '/test/hunner',
+            home_mode            => '0700',
             bashrc_content       => file('accounts/shell/bashrc'),
             bash_profile_content => file('accounts/shell/bash_profile'),
             sshkeys              => [
@@ -47,6 +48,7 @@ pp_custom_group_name = <<-PUPPETCODE
             group                => 'staff',
             password             => '!!',
             home                 => '/test/cuser',
+            home_mode            => '0700',
           }
 PUPPETCODE
 


### PR DESCRIPTION
Default `mode` for `accounts::home_dir` to undef. If `accounts::user`
accepts and defaults to undef, so should `accounts::home_dir`.


This way `manage_home` can still be true so puppet will create homedir (based on umask) and manage sshkeys in it, while allowing users to manage their own permissions if we don't explicitly specify mode when creating `accounts::user` resource.