### PR TITLE
(MODULES-3989) Allow management of local accounts despite an NSS

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -158,6 +158,10 @@ Specifies the user's group memberships. Valid values: an array. Default: an empt
 
 Specifies if you want to create a group with the user's name. Default: true.
 
+#### `forcelocal`
+
+Specifies if you want to manage a local user/group that is also managed by a network name service. Default: undef.
+
 #### `home`
 
 Specifies the path to the user's home directory.

--- a/README.markdown
+++ b/README.markdown
@@ -160,7 +160,7 @@ Specifies if you want to create a group with the user's name. Default: true.
 
 #### `forcelocal`
 
-Specifies if you want to manage a local user/group that is also managed by a network name service. Default: undef.
+Specifies if you want to manage a local user/group that is also managed by a network name service. Valid values: true, false. Default: undef.
 
 #### `home`
 

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -21,6 +21,7 @@ define accounts::user(
   $groups                   = [ ],
   $create_group             = true,
   $membership               = 'minimum',
+  $forcelocal               = undef,
   $password                 = '!!',
   $locked                   = false,
   $sshkeys                  = [],
@@ -108,14 +109,16 @@ define accounts::user(
     # Ensure that the group hasn't already been defined
     if $ensure == 'present' and ! defined(Group[$group]) {
       group { $group:
-        ensure => $ensure,
-        gid    => $gid,
-        system => $system,
+        ensure     => $ensure,
+        gid        => $gid,
+        system     => $system,
+        forcelocal => $forcelocal,
       }
     # Only remove the group if it is the same as user name as it may be shared
     } elsif $ensure == 'absent' and $name == $group {
       group { $group:
-        ensure => $ensure,
+        ensure     => $ensure,
+        forcelocal => $forcelocal,
       }
     }
   }
@@ -133,6 +136,7 @@ define accounts::user(
       managehome     => $managehome,
       purge_ssh_keys => $purge_sshkeys,
       system         => $system,
+      forcelocal     => $forcelocal,
     }
   } else {
     user { $name:
@@ -148,6 +152,7 @@ define accounts::user(
       password       => $password,
       purge_ssh_keys => $purge_sshkeys,
       system         => $system,
+      forcelocal     => $forcelocal,
     }
   }
 

--- a/spec/defines/accounts_user_spec.rb
+++ b/spec/defines/accounts_user_spec.rb
@@ -153,7 +153,7 @@ describe '::accounts::user' do
         params['forcelocal'] = false
       end
 
-      it { is_expected.to contain_user( 'dan').with('forcelocal' => false) }
+      it { is_expected.to contain_user('dan').with('forcelocal' => false) }
       it { is_expected.to contain_group('dan').with('forcelocal' => false) }
     end
 
@@ -162,7 +162,7 @@ describe '::accounts::user' do
         params['forcelocal'] = true
       end
 
-      it { is_expected.to contain_user( 'dan').with('forcelocal' => true) }
+      it { is_expected.to contain_user('dan').with('forcelocal' => true) }
       it { is_expected.to contain_group('dan').with('forcelocal' => true) }
     end
   end

--- a/spec/defines/accounts_user_spec.rb
+++ b/spec/defines/accounts_user_spec.rb
@@ -147,6 +147,24 @@ describe '::accounts::user' do
 
       it { is_expected.to contain_group('foo') }
     end
+
+    describe 'when setting forcelocal to false' do
+      before(:each) do
+        params['forcelocal'] = false
+      end
+
+      it { is_expected.to contain_user( 'dan').with('forcelocal' => false) }
+      it { is_expected.to contain_group('dan').with('forcelocal' => false) }
+    end
+
+    describe 'when setting forcelocal to true' do
+      before(:each) do
+        params['forcelocal'] = true
+      end
+
+      it { is_expected.to contain_user( 'dan').with('forcelocal' => true) }
+      it { is_expected.to contain_group('dan').with('forcelocal' => true) }
+    end
   end
 
   describe 'when setting user parameters with empty password ignored if true' do


### PR DESCRIPTION
Add the forcelocal parameter to accounts::user to allow the module to
manage local users and groups when they are also being managed by some
other network name service.