### PR TITLE
Allow sshkeys to be reused for multiple accounts

### DIFF
--- a/manifests/home_dir.pp
+++ b/manifests/home_dir.pp
@@ -119,11 +119,13 @@ define accounts::home_dir(
     }
 
     if $sshkeys != [] {
-      accounts::manage_keys { $sshkeys:
-        user     => $user,
-        key_file => $key_file,
-        require  => File["${name}/.ssh"],
-        before   => File[$key_file],
+      $sshkeys.each |$sshkey| {
+        accounts::manage_keys { "${sshkey} for ${user}":
+          user     => $user,
+          key_file => $key_file,
+          require  => File["${name}/.ssh"],
+          before   => File[$key_file],
+        }
       }
     }
   }

--- a/manifests/manage_keys.pp
+++ b/manifests/manage_keys.pp
@@ -23,7 +23,6 @@ define accounts::manage_keys(
   ssh_authorized_key { $key_title:
     ensure  => present,
     user    => $user,
-    name    => $key_name,
     key     => $key_content,
     type    => $key_type,
     options => $key_options,

--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -156,8 +156,8 @@ describe 'accounts::user define', unless: UNSUPPORTED_PLATFORMS.include?(fact('o
       it('has authorized_key - vagrant', unless: default['platform'].match(%r{solaris-10})) {
         is_expected.to have_authorized_key "ssh-rsa #{test_key} vagrant"
       }
-      it('has authorized_key - vagrant2', unless: default['platform'].match(%r{solaris-10})) {
-        is_expected.to have_authorized_key "from=\"myhost.example.com,192.168.1.1\" ssh-rsa #{test_key} vagrant2"
+      it('has authorized_key - hunner_ssh-rsa_vagrant2', unless: default['platform'].match(%r{solaris-10})) {
+        is_expected.to have_authorized_key "from=\"myhost.example.com,192.168.1.1\" ssh-rsa #{test_key} hunner_ssh-rsa_vagrant2"
       }
     end
     describe file('/test/hunner') do


### PR DESCRIPTION
This avoids duplicate resources errors when associating the same SSH public key to different accounts on the same node.