### PR TITLE
Removes validate_* and replaces them with validate_legacy

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,6 +2,6 @@ fixtures:
   repositories:
     "stdlib":
       "repo": "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-      "ref": "4.5.0"
+      "ref": "4.14.0"
   symlinks:
     "accounts": "#{source_dir}"

--- a/manifests/home_dir.pp
+++ b/manifests/home_dir.pp
@@ -19,7 +19,7 @@ define accounts::home_dir(
   $ensure               = 'present',
   $sshkeys              = [],
 ) {
-  validate_re($ensure, '^(present|absent)$')
+  validate_legacy(String, 'validate_re', $ensure, '^(present|absent)$')
 
   if $ensure == 'absent' {
     file { $name:

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -36,34 +36,34 @@ define accounts::user(
   $forward_content           = undef,
   $forward_source            = undef,
 ) {
-  validate_re($ensure, '^present$|^absent$')
-  validate_bool($locked, $managehome, $purge_sshkeys, $ignore_password_if_empty)
-  validate_re($shell, '^/')
-  validate_string($comment, $password, $group)
-  validate_array($groups, $sshkeys)
-  validate_re($membership, '^inclusive$|^minimum$')
+  validate_legacy(String, 'validate_re', $ensure, '^present$|^absent$')
+  validate_legacy(Boolean, 'validate_bool', $locked, $managehome, $purge_sshkeys, $ignore_password_if_empty)
+  validate_legacy(String, 'validate_re', $shell, '^/')
+  validate_legacy(String, 'validate_string', $comment, $password, $group)
+  validate_legacy(Tuple, 'validate_array', $groups, $sshkeys)
+  validate_legacy(String, 'validate_re', $membership, '^inclusive$|^minimum$')
   if $bashrc_content {
-    validate_string($bashrc_content)
+    validate_legacy(String, 'validate_string', $bashrc_content)
   }
   if $bashrc_source {
-    validate_string($bashrc_source)
+    validate_legacy(String, 'validate_string', $bashrc_source)
   }
   if $bash_profile_content {
-    validate_string($bash_profile_content)
+    validate_legacy(String, 'validate_string', $bash_profile_content)
   }
   if $bash_profile_source {
-    validate_string($bash_profile_source)
+    validate_legacy(String, 'validate_string', $bash_profile_source)
   }
   if $forward_content {
-    validate_string($forward_content)
+    validate_legacy(String, 'validate_string', $forward_content)
   }
   if $forward_source {
-    validate_string($forward_source)
+    validate_legacy(String, 'validate_string', $forward_source)
   }
   if $home {
-    validate_re($home, '^/')
+    validate_legacy(String, 'validate_re', $home, '^/')
     # If the home directory is not / (root on solaris) then disallow trailing slashes.
-    validate_re($home, '^/$|[^/]$')
+    validate_legacy(String, 'validate_re', $home, '^/$|[^/]$')
   }
 
   if $home {
@@ -81,11 +81,11 @@ define accounts::user(
   }
 
   if $uid != undef {
-    validate_re($uid, '^\d+$')
+    validate_legacy(String, 'validate_re', $uid, '^\d+$')
   }
 
   if $gid != undef {
-    validate_re($gid, '^\d+$')
+    validate_legacy(String, 'validate_re', $gid, '^\d+$')
   }
 
   if $locked {

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 3.4.0 < 5.0.0"
+      "version_requirement": ">= 4.14.0 < 5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Puppet's stdlib is about the depricate the validate_* functions.
Replaces them with the new validate_legacy function and the
correct syntax.