### PR TITLE
Adding abbility to specify custom ssh_key location

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -104,6 +104,12 @@ accounts::user { 'jeff':
 }
 ~~~
 
+The module supports placing sshkeys in a custom location. If you specify a value
+for the `sshkey_custom_path` attribute of the `accounts::user` defined type the
+module will place the keys in the specified file. The module will only manage
+the specified file and not the full path. If you set `purge_sshkeys` to true and
+you have set a custom path then ssh keys in the custom path will be purged. 
+
 ## Reference
 
 ### Defined type: `accounts::user`

--- a/README.markdown
+++ b/README.markdown
@@ -108,7 +108,27 @@ The module supports placing sshkeys in a custom location. If you specify a value
 for the `sshkey_custom_path` attribute of the `accounts::user` defined type the
 module will place the keys in the specified file. The module will only manage
 the specified file and not the full path. If you set `purge_sshkeys` to true and
-you have set a custom path then ssh keys in the custom path will be purged. 
+you have set a custom path then only ssh keys in the custom path will be purged.
+Example:
+~~~puppet
+accounts::user { 'gerrard':
+  sshkey_custom_path => '/var/lib/ssh/gerrard/authorized_keys',
+  shell              => '/bin/zsh',
+  comment            => 'Gerrard Geldenhuis',
+  groups             => [
+    'engineering',
+    'automation',
+  ],
+  uid                => '1117',
+  gid                => '1117',
+  sshkeys            => [
+    'ssh-rsa AAAAB9Aza...== gerrard@dirtyfruit.co.uk',
+    'ssh-dss AAAAB9Aza...== gerrard@dojo.training',
+  ],
+  password           => '!!',
+}
+~~~
+Setting `sshkey_custom_path` will typically be associated with setting `AuthorizedKeysFile /var/lib/ssh/%u/authorized_keys` in your sshd config file.
 
 ## Reference
 

--- a/examples/custom_key_location.pp
+++ b/examples/custom_key_location.pp
@@ -22,20 +22,20 @@ file { '/var/lib/ssh/jeff':
 
 accounts::user { 'jeff':
   sshkey_custom_path => '/var/lib/ssh/jeff/authorized_keys',
-  shell    => '/bin/zsh',
-  comment  => 'Jeff McCune',
-  groups   => [
+  shell              => '/bin/zsh',
+  comment            => 'Jeff McCune',
+  groups             => [
     'admin',
     'sudonopw',
   ],
-  uid      => '1112',
-  gid      => '1112',
-  locked   => true,
-  sshkeys  => [
+  uid                => '1112',
+  gid                => '1112',
+  locked             => true,
+  sshkeys            => [
     'ssh-rsa AAAAB3Nza...== jeff@puppetlabs.com',
     'ssh-dss AAAAB3Nza...== jeff@metamachine.net',
   ],
-  password => '!!',
+  password           => '!!',
 }
 accounts::user { 'dan':
   comment => 'Dan Bode',

--- a/examples/custom_key_location.pp
+++ b/examples/custom_key_location.pp
@@ -1,0 +1,44 @@
+group { 'admin':
+  gid => 3000,
+}
+group { 'sudo':
+  gid => 3001,
+}
+group { 'sudonopw':
+  gid => 3002,
+}
+group { 'developer':
+  gid => 3003,
+}
+group { 'ops':
+  gid => 3004,
+}
+
+file { '/var/lib/ssh/jeff':
+  ensure => directory,
+  owner  => 'jeff',
+  group  => 'jeff',
+}
+
+accounts::user { 'jeff':
+  sshkey_custom_path => '/var/lib/ssh/jeff/authorized_keys',
+  shell    => '/bin/zsh',
+  comment  => 'Jeff McCune',
+  groups   => [
+    'admin',
+    'sudonopw',
+  ],
+  uid      => '1112',
+  gid      => '1112',
+  locked   => true,
+  sshkeys  => [
+    'ssh-rsa AAAAB3Nza...== jeff@puppetlabs.com',
+    'ssh-dss AAAAB3Nza...== jeff@metamachine.net',
+  ],
+  password => '!!',
+}
+accounts::user { 'dan':
+  comment => 'Dan Bode',
+  uid     => '1109',
+  gid     => '1109',
+}

--- a/examples/custom_key_location_purge_keys.pp
+++ b/examples/custom_key_location_purge_keys.pp
@@ -22,19 +22,19 @@ file { '/var/lib/ssh/jeff':
 
 accounts::user { 'jeff':
   sshkey_custom_path => '/var/lib/ssh/jeff/authorized_keys',
-  shell    => '/bin/zsh',
-  comment  => 'Jeff McCune',
-  purge_sshkeys => true,
-  groups   => [
+  shell              => '/bin/zsh',
+  comment            => 'Jeff McCune',
+  purge_sshkeys      => true,
+  groups             => [
     'admin',
     'sudonopw',
   ],
-  uid      => '1112',
-  gid      => '1112',
-  locked   => true,
-  sshkeys  => [
+  uid                => '1112',
+  gid                => '1112',
+  locked             => true,
+  sshkeys            => [
     'ssh-rsa BBBBB3Nza...== jeff@puppetlabs.com',
     'ssh-dss BBBBB3Nza...== jeff@metamachine.net',
   ],
-  password => '!!',
+  password           => '!!',
 }

--- a/examples/custom_key_location_purge_keys.pp
+++ b/examples/custom_key_location_purge_keys.pp
@@ -1,0 +1,40 @@
+group { 'admin':
+  gid => 3000,
+}
+group { 'sudo':
+  gid => 3001,
+}
+group { 'sudonopw':
+  gid => 3002,
+}
+group { 'developer':
+  gid => 3003,
+}
+group { 'ops':
+  gid => 3004,
+}
+
+file { '/var/lib/ssh/jeff':
+  ensure => directory,
+  owner  => 'jeff',
+  group  => 'jeff',
+}
+
+accounts::user { 'jeff':
+  sshkey_custom_path => '/var/lib/ssh/jeff/authorized_keys',
+  shell    => '/bin/zsh',
+  comment  => 'Jeff McCune',
+  purge_sshkeys => true,
+  groups   => [
+    'admin',
+    'sudonopw',
+  ],
+  uid      => '1112',
+  gid      => '1112',
+  locked   => true,
+  sshkeys  => [
+    'ssh-rsa BBBBB3Nza...== jeff@puppetlabs.com',
+    'ssh-dss BBBBB3Nza...== jeff@metamachine.net',
+  ],
+  password => '!!',
+}

--- a/examples/user_group.pp
+++ b/examples/user_group.pp
@@ -21,8 +21,8 @@ accounts::user { 'jeff':
     'admin',
     'sudonopw',
   ],
-  uid      => 1112,
-  gid      => 1112,
+  uid      => '1112',
+  gid      => '1112',
   locked   => true,
   sshkeys  => [
     'ssh-rsa AAAAB3Nza...== jeff@puppetlabs.com',

--- a/manifests/key_management.pp
+++ b/manifests/key_management.pp
@@ -47,5 +47,4 @@ define accounts::key_management(
     }
   }
 
-
 }

--- a/manifests/key_management.pp
+++ b/manifests/key_management.pp
@@ -11,7 +11,7 @@ define accounts::key_management(
   $user,
   $group,
   $user_home,
-  $sshkeys = [],
+  $sshkeys            = [],
   $sshkey_custom_path = undef,
 ) {
 

--- a/manifests/key_management.pp
+++ b/manifests/key_management.pp
@@ -1,0 +1,51 @@
+#
+# Specify where ssh keys are managed
+#
+# [*group*] Name of the users primary group
+# [*user*] User that owns all of the files being created.
+# [*sshkeys*] List of ssh keys to be added for this user in this
+# directory
+# [*sshkey_custom_path*] Path for custom file for ssh key management
+#
+define accounts::key_management(
+  $user,
+  $group,
+  $user_home,
+  $sshkeys = [],
+  $sshkey_custom_path = undef,
+) {
+
+  file { "${user_home}/.ssh":
+    ensure => directory,
+    owner  => $user,
+    group  => $group,
+    mode   => '0700',
+  }
+
+  if $sshkey_custom_path != undef {
+    $key_file = $sshkey_custom_path
+  }
+  else {
+    $key_file = "${user_home}/.ssh/authorized_keys"
+  }
+
+  file { $key_file:
+    ensure => file,
+    owner  => $user,
+    group  => $group,
+    mode   => '0600',
+  }
+
+  if $sshkeys != [] {
+    $sshkeys.each |$sshkey| {
+      accounts::manage_keys { "${sshkey} for ${user}":
+        user     => $user,
+        key_file => $key_file,
+        require  => File["${user_home}/.ssh"],
+        before   => File[$key_file],
+      }
+    }
+  }
+
+
+}

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -36,7 +36,7 @@ define accounts::user(
   $forward_content          = undef,
   $forward_source           = undef,
   $expiry                   = undef,
-  $sshkey_custom_path       = undef,
+  Optional[String] $sshkey_custom_path = undef,
 ) {
   validate_re($ensure, '^present$|^absent$')
   validate_bool($locked, $managehome, $purge_sshkeys, $ignore_password_if_empty)

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -133,7 +133,7 @@ define accounts::user(
 
   if $purge_sshkeys {
     if $sshkey_custom_path != undef {
-      $purge_sshkeys_value = ["${sshkey_custom_path}"]
+      $purge_sshkeys_value = ["${sshkey_custom_path}"] # lint:ignore:only_variable_string
     }
     else { $purge_sshkeys_value = true }
   }

--- a/spec/defines/accounts_user_spec.rb
+++ b/spec/defines/accounts_user_spec.rb
@@ -99,6 +99,13 @@ describe '::accounts::user' do
     it { is_expected.to contain_accounts__key_management('dan_key_management').with('sshkeys' => ['1 2 3', '2 3 4']) }
     it { is_expected.to contain_file('/var/home/dan/.ssh') }
 
+    describe 'when setting custom sshkey location' do
+      before(:each) do
+        params['sshkey_custom_path'] = '/var/lib/ssh/dan/custom_key_file'
+      end
+      it { is_expected.to contain_file('/var/lib/ssh/dan/custom_key_file') }
+    end
+
     describe 'when setting the user to absent' do
       # when deleting users the home dir is a File resource instead of a accounts::home_dir
       let(:contain_home_dir) { contain_file('/var/home/dan') }

--- a/spec/defines/accounts_user_spec.rb
+++ b/spec/defines/accounts_user_spec.rb
@@ -96,7 +96,7 @@ describe '::accounts::user' do
     it { is_expected.to contain_group('dan').that_comes_before('User[dan]') }
     it { is_expected.to contain_accounts__home_dir('/var/home/dan').with('user' => title) }
     it { is_expected.to contain_accounts__home_dir('/var/home/dan').with('mode' => '0755') }
-    it { is_expected.to contain_accounts__home_dir('/var/home/dan').with('sshkeys' => ['1 2 3', '2 3 4']) }
+    it { is_expected.to contain_accounts__key_management('dan_key_management').with('sshkeys' => ['1 2 3', '2 3 4']) }
     it { is_expected.to contain_file('/var/home/dan/.ssh') }
 
     describe 'when setting the user to absent' do


### PR DESCRIPTION
This PR is not meant to be merged immediately but rather to kick of a discussion about the added functionality. It is currently missing spec tests but is otherwise properly functioning albeit undocumented.

In an ideal world the implementation should happen in the user class and the various but of ssh key functionality should be moved out of home_dir class. This implementation however achieves the functionality required with the minimum of changes.

In my PR I have made the assumption that when _purge_sshkeys_ are set to true that the intent is to delete all user related keys. Thus if the user has specified a custom ssh key location, unspecified keys in the custom location and the user's home directory will be removed. I am not sure if it is worthwhile to offer a differentiated ability to purge custom and purge home directory. A potential alternative is to only purge custom specified directory. 

I created [PUP-8982](https://tickets.puppetlabs.com/browse/PUP-8982) as a result of my testing. Additionally the ssh_authorized_key resource does not allow for changing the ownership of the sshkey file other than to the user for whom the key is being generated. This is a false assumption if you are storing keys in a different location and specifying _AuthorizedKeysFile_, _AuthorizedKeysCommand_ and _AuthorizedKeysCommandUser_ in _sshd_config_. Specifying these values in _sshd_config_ allows you to centralise user ssh keys and disallow the user from modifying them. 