### PR TITLE
(MODULES-7671) - Support spaces in ssh key options

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -235,7 +235,14 @@ Manages the user shell. Default: '/bin/bash'.
 
 #### `sshkeys`
 
-An array of SSH public keys associated with the user. These should be complete public key strings that include the type and name of the key, exactly as the key would appear in its id\_rsa.pub or id\_dsa.pub file. Must be an array. Default: an empty array.
+An array of SSH public keys associated with the user. These should be complete public key strings that include the type, content and name of the key, exactly as it would appear in its `id_*.pub` file, or with an optional options string preceding the other components, as it would appear as an entry in an `authorized_keys` file.  Must be an array. Default: an empty array.
+
+Examples:
+
+* `ssh-rsa AAAAB3NzaC1y... bob@example.com`
+* `from="myhost.example.com,192.168.1.1" ssh-rsa AAAAQ4ngoeiC... bob2@example.com`
+
+Note that for multiple keys, the name component (the last) must be unique.
 
 #### `uid`
 

--- a/manifests/key_management.pp
+++ b/manifests/key_management.pp
@@ -39,6 +39,7 @@ define accounts::key_management(
   if $sshkeys != [] {
     $sshkeys.each |$sshkey| {
       accounts::manage_keys { "${sshkey} for ${user}":
+        keyspec  => $sshkey,
         user     => $user,
         key_file => $key_file,
         require  => [

--- a/manifests/manage_keys.pp
+++ b/manifests/manage_keys.pp
@@ -1,31 +1,33 @@
 #
 define accounts::manage_keys(
+  $keyspec,
   $user,
   $key_file,
 ) {
 
-  $key_array   = split($name, ' ')
-  # If the key array doesn't start with ssh or ecdsa, then key_array[0] is
-  # assumed to contain ssh options separated by commas.
-  if $key_array[0] =~ /^ssh|^ecdsa-sha2/ {
-    $key_options = undef
-    $key_type    = $key_array[0]
-    $key_content = $key_array[1]
-    $key_name    = $key_array[2]
-  } else {
-    $key_options = accounts_ssh_options_parser($key_array[0])
-    $key_type    = $key_array[1]
-    $key_content = $key_array[2]
-    $key_name    = $key_array[3]
+  $key_def = $keyspec.match(/^((.*)\s+)?((ssh|ecdsa-sha2).*)\s+(.*)\s+(.*)$/)
+  if (! $key_def) {
+    err("Could not interpret SSH key definition: '$keyspec'")
   }
-  $key_title = "${user}_${key_type}_${key_name}"
+  else {
+    if ($key_def[2]) {
+      $key_options = accounts_ssh_options_parser($key_def[2])
+    } else {
+      $key_options = undef
+    }
+    $key_type    = $key_def[3]
+    $key_content = $key_def[5]
+    $key_name    = $key_def[6]
 
-  ssh_authorized_key { $key_title:
-    ensure  => present,
-    user    => $user,
-    key     => $key_content,
-    type    => $key_type,
-    options => $key_options,
-    target  => $key_file,
+    $key_title = "${user}_${key_type}_${key_name}"
+
+    ssh_authorized_key { $key_title:
+      ensure  => present,
+      user    => $user,
+      key     => $key_content,
+      type    => $key_type,
+      options => $key_options,
+      target  => $key_file,
+    }
   }
 }

--- a/manifests/manage_keys.pp
+++ b/manifests/manage_keys.pp
@@ -7,7 +7,7 @@ define accounts::manage_keys(
 
   $key_def = $keyspec.match(/^((.*)\s+)?((ssh|ecdsa-sha2).*)\s+(.*)\s+(.*)$/)
   if (! $key_def) {
-    err("Could not interpret SSH key definition: '$keyspec'")
+    err("Could not interpret SSH key definition: '${keyspec}'")
   }
   else {
     if ($key_def[2]) {

--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -19,7 +19,7 @@ pp_accounts_define = <<-PUPPETCODE
             bash_profile_content => file('accounts/shell/bash_profile'),
             sshkeys              => [
               'ssh-rsa #{test_key} vagrant',
-              'from="myhost.example.com,192.168.1.1" ssh-rsa #{test_key} vagrant2'
+              'command="/bin/echo Hello",from="myhost.example.com,192.168.1.1" ssh-rsa #{test_key} vagrant2'
             ],
           }
 PUPPETCODE


### PR DESCRIPTION
This PR attempts to resolve an issue described in the [modules-7671](https://tickets.puppetlabs.com/browse/MODULES-7671) where a user's SSH key specifications may include options as would appear in an `authorized_keys` file, but the parsing fails on options that include a space, which should be valid.  Instead of splitting the key specification string on spaces this PR uses a regular expression and support both simple (type-content-name) and less simple (options-type-content-name).  Documentation is also updated to clarify that keys can include options, and that they must include the name component.