### PR TITLE
(FM-7288) - Update comments to work with Puppet Strings

### DIFF
--- a/manifests/home_dir.pp
+++ b/manifests/home_dir.pp
@@ -1,11 +1,42 @@
+# @summary
+#   This resource specifies how home directories are managed.
 #
-# Specified how home directories are managed.
+# @param group
+#   Name of the user's primary group.
 #
-# [*name*] Name of the home directory that is being managed.
-# [*group*] Name of the users primary group
-# [*user*] User that owns all of the files being created.
-# [*sshkeys*] List of ssh keys to be added for this user in this
-# directory
+# @param user 
+#   Name of the user that owns all of the files being created.
+#
+# @param bashrc_content 
+#   The content to place in the user's ~/.bashrc file. Mutually exclusive to bashrc_source.
+#
+# @param bashrc_source
+#   A source file containing the content to place in the user's ~/.bashrc file. Mutually exclusive to bashrc_content.
+#
+# @param bash_profile_content
+#   The content to place in the user's ~/.bash_profile file. Mutually exclusive to bash_profile_source.
+#
+# @param bash_profile_source
+#   A source file containing the content to place in the user's ~/.bash_profile file. Mutually exclusive to bash_profile_content. 
+#
+# @param forward_content
+#   The content to place in the user's ~/.forward file. Mutually exclusive to forward_source. 
+#
+# @param forward_source
+#   A source file containing the content to place in the user's ~/.forward file. Mutually exclusive to forward_content. 
+#
+# @param mode
+#   Manages the user's home directory permission mode. Valid values are in octal notation.
+#
+# @param ensure
+#   Specifies whether the user, its primary group, homedir, and ssh keys should exist. Valid values are 'present' and 'absent'. Note that 
+#   when a user is created, a group with the same name as the user is also created. 
+#
+# @param name 
+#   Path of the home directory that is being managed.
+#
+# @api private
+#
 define accounts::home_dir(
   String $user,
   String $group,

--- a/manifests/key_management.pp
+++ b/manifests/key_management.pp
@@ -1,11 +1,22 @@
+# @summary
+#   This resource specifies where ssh keys are managed.
 #
-# Specify where ssh keys are managed
+# @param group 
+#   Name of the users primary group.
 #
-# [*group*] Name of the users primary group
-# [*user*] User that owns all of the files being created.
-# [*sshkeys*] List of ssh keys to be added for this user in this
-# directory
-# [*sshkey_custom_path*] Path for custom file for ssh key management
+# @param user 
+#   User that owns all of the files being created.
+#
+# @param user_home
+#   Specifies the path to the user's home directory.
+#
+# @param sshkeys 
+#   List of ssh keys to be added for this user in this directory.
+#
+# @param sshkey_custom_path 
+#   Path to custom file for ssh key management.
+#
+# @api private
 #
 define accounts::key_management(
   String $user,

--- a/manifests/manage_keys.pp
+++ b/manifests/manage_keys.pp
@@ -1,3 +1,13 @@
+# @summary
+#   This resource manages ssh keys for a user.
+#
+# @param user 
+#   User that owns the file supplied.
+#
+# @param key_file
+#   Specifies the path of the ssh key file.
+#
+# @api private
 #
 define accounts::manage_keys(
   String $user,

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -1,13 +1,126 @@
+# @summary 
+#   This resource manages the user, group, vim/, .ssh/, .bash_profile, .bashrc, homedir, .ssh/authorized_keys files, and directories.
+# 
+# @example Basic usage
+#   accounts::user { 'bob':
+#     uid      => '4001',
+#     gid      => '4001',
+#     group    => 'staff',
+#     shell    => '/bin/bash',
+#     password => '!!',
+#     locked   => false,
+#   }
 #
+# @param ensure
+#   Specifies whether the user, its primary group, homedir, and ssh keys should exist. Valid values are 'present' and 'absent'. Note that 
+#   when a user is created, a group with the same name as the user is also created. 
 #
-# parameters:
-# [*name*] Name of user
-# [*group*] Name of user's primary group (defaults to user name)
-# [*locked*] Whether the user account should be locked.
-# [*sshkeys*] List of ssh public keys to be associated with the
-# user.
-# [*managehome*] Whether the home directory should be removed with accounts
-# [*system*] Whether the account should be a member of the system accounts
+# @param shell 
+#   Manages the user shell.
+#
+# @param comment 
+#   A comment describing or regarding the user.
+#
+# @param home 
+#   Specifies the path to the user's home directory.
+#
+#   - Linux, non-root user: '/home/$name'
+#
+#   - Linux, root user: '/root'
+#
+#   - Solaris, non-root user: '/export/home/$name'
+#
+#   - Solaris, root user: '/'
+#
+# @param home_mode 
+#   Manages the user's home directory permission mode. Valid values are in octal notation, specified as a string. Defaults to undef, 
+#   which creates a home directory with 0700 permissions. It does not touch them if the directory already exists. Keeping it undef also 
+#   allows a user to manage their own permissions. If home_mode is set, Puppet enforces the permissions on every run.
+#
+# @param uid 
+#   Specifies the user's uid number. Must be specified numerically.
+#
+# @param gid 
+#   Specifies the gid of the user's primary group. Must be specified numerically. 
+#
+# @param group
+#   Specifies the name of the user's primary group. By default, this uses a group named the same as user name
+#
+# @param groups
+#   Specifies the user's group memberships.
+#
+# @param create_group
+#   Specifies if you want to create a group with the user's name. 
+#
+# @param membership
+#   Establishes whether specified groups should be considered the complete list (inclusive) or the minimum list (minimum) of groups to 
+#   which the user belongs. Valid values: 'inclusive', 'minimum'.
+#   
+# @param forcelocal
+#   Specifies whether you want to manage a local user/group that is also managed by a network name service.
+#
+# @param password
+#   The user's password, in whatever encrypted format the local machine requires. Default: '!!', which prevents the user from logging in 
+#   with a password.
+#   
+# @param locked
+#   Specifies whether the account should be locked and the user prevented from logging in. Set to true for users whose login privileges 
+#   have been revoked.
+#
+# @param sshkeys
+#   An array of SSH public keys associated with the user. These should be complete public key strings that include the type, content and 
+#   name of the key, exactly as it would appear in its id_*.pub file, or with an optional options string preceding the other components, 
+#   as it would appear as an entry in an authorized_keys file. Must be an array. 
+#
+#   Examples:
+#
+#   - ssh-rsa AAAAB3NzaC1y... bob@example.com
+#
+#   - from="myhost.example.com,192.168.1.1" ssh-rsa AAAAQ4ngoeiC... bob2@example.com
+#
+#   Note that for multiple keys, the name component (the last) must be unique.
+#
+# @param purge_sshkeys
+#   Whether keys not included in sshkeys should be removed from the user. If purge_sshkeys is true and sshkeys is an empty array, all SSH 
+#   keys will be removed from the user.
+#   
+# @param managehome
+#   Specifies whether the user's home directory should be managed by puppet. In addition to the usual user resource managehome qualities, 
+#   this attribute also purges the user's homedir if ensure is set to 'absent' and managehome is set to true.
+#
+# @param bashrc_content 
+#   The content to place in the user's ~/.bashrc file. Mutually exclusive to bashrc_source.
+#
+# @param bashrc_source
+#   A source file containing the content to place in the user's ~/.bashrc file. Mutually exclusive to bashrc_content.
+#
+# @param bash_profile_content
+#   The content to place in the user's ~/.bash_profile file. Mutually exclusive to bash_profile_source.
+#
+# @param bash_profile_source
+#   A source file containing the content to place in the user's ~/.bash_profile file. Mutually exclusive to bash_profile_content. 
+#
+# @param system
+#   Specifies if you want to create a system account. 
+#
+# @param ignore_password_if_empty
+#   Specifies whether an empty password field should be ignored. If set to true, this ignores a password field that is defined but 
+#   empty. If set to false, it sets the password to an empty value.
+#
+# @param forward_content
+#   The content to place in the user's ~/.forward file. Mutually exclusive to forward_source. 
+#
+# @param forward_source
+#   A source file containing the content to place in the user's ~/.forward file. Mutually exclusive to forward_content. 
+#
+# @param expiry
+#   Specifies the date the user account expires on. Valid values: YYYY-MM-DD date format, or 'absent' to remove expiry date.
+#
+# @param sshkey_custom_path
+#   Custom location for ssh public key file.
+#
+# @param name
+#   Name of the user.
 #
 define accounts::user(
   Pattern[/^present$|^absent$/] $ensure         = 'present',
@@ -38,7 +151,7 @@ define accounts::user(
   Optional[Pattern[/^absent$|^\d{4}-\d{2}-\d{2}$/]] $expiry = undef,
   Optional[String] $sshkey_custom_path          = undef,
 ) {
-  
+
   if $home {
     $home_real = $home
   } elsif $name == 'root' {


### PR DESCRIPTION
The comments in manifests/*.pp have been updated to provide the correct information when documentation is generated by Puppet Strings.