### PR TITLE
pdksync - (MODULES-7658) use beaker4 in puppet-module-gems

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,3 +1,5 @@
+require 'beaker-pe'
+require 'beaker-puppet'
 require 'beaker-rspec'
 require 'beaker/puppet_install_helper'
 require 'beaker/module_install_helper'
@@ -7,6 +9,7 @@ require 'beaker-task_helper'
 UNSUPPORTED_PLATFORMS = ['windows', 'Darwin'].freeze
 
 run_puppet_install_helper
+configure_type_defaults_on(hosts)
 install_module_on(hosts)
 install_module_dependencies_on(hosts)
 


### PR DESCRIPTION
(MODULES-7658) use beaker4 in puppet-module-gems
pdk version: `1.7.0` 
