### PR TITLE
Only take care of ssh-keys if ensure is set to 'present'

### DIFF
--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -284,18 +284,20 @@ define accounts::user(
       group                => $group,
       require              => [ User[$name] ],
     }
-    accounts::key_management { "${name}_key_management":
-      user               => $name,
-      group              => $group,
-      user_home          => $_home,
-      sshkeys            => $sshkeys,
-      sshkey_custom_path => $sshkey_custom_path,
-      require            => Accounts::Home_dir[$_home]
+    if ( $ensure == 'present' ) {
+      accounts::key_management { "${name}_key_management":
+        user               => $name,
+        group              => $group,
+        user_home          => $_home,
+        sshkeys            => $sshkeys,
+        sshkey_custom_path => $sshkey_custom_path,
+        require            => Accounts::Home_dir[$_home]
+      }
     }
   } elsif $sshkeys != [] {
     # We are not managing the user's home directory but we have specified a
     # custom, non-home directory for the ssh keys.
-      if $sshkey_custom_path != undef {
+      if (($sshkey_custom_path != undef) and ($ensure == 'present')) {
         accounts::key_management { "${name}_key_management":
           user               => $name,
           group              => $group,


### PR DESCRIPTION
Trying to remove a user by simply setting "ensure = absent" leads to the following errors:

Error: Cannot create /home/USERNAME/.ssh; parent directory /home/USERNAME does not exist
Error: /Stage[main]/Fcsbase::Install/Accounts::User[USERNAME]/Accounts::Key_management[USERNAME_key_management]/File[/home/USERNAME/.ssh]/ensure: change from absent to directory failed: Cannot create /home/USERNAME/.ssh; parent directory /home/USERNAME does not exist
Notice: /Stage[main]/Fcsbase::Install/Accounts::User[USERNAME]/Accounts::Key_management[USERNAME_key_management]/File[/home/USERNAME/.ssh/authorized_keys]: Dependency File[/home/USERNAME/.ssh] has failures: true
Warning: /Stage[main]/Fcsbase::Install/Accounts::User[USERNAME]/Accounts::Key_management[USERNAME_key_management]/File[/home/USERNAME/.ssh/authorized_keys]: Skipping because of failed dependencies


I added checking ensure == present before instantiation of accounts::key_management to be able to cleanly remove users without warnings and errors.