### PR TITLE
(MODULES-8909) Allow periods in usernames.

### DIFF
--- a/spec/acceptance/accounts_spec.rb
+++ b/spec/acceptance/accounts_spec.rb
@@ -85,10 +85,10 @@ hd_locked_user = hd_defaults.merge(
 
 hd_custom_group_name = hd_defaults.merge(
   'accounts::user_list' => {
-    'cuser' => {
+    'first.last' => {
       'group'     => 'staff',
       'password'  => '!!',
-      'home'      => '/test/cuser',
+      'home'      => '/test/first.last',
     },
   },
 )
@@ -210,7 +210,7 @@ pp_cleanup = <<-PUPPETCODE
   ensure_resource('file', $files, $file_params)
   $users = [
     'hunner',
-    'cuser',
+    'first.last',
     'grp_flse',
     'grp_true',
     'ignore_user',
@@ -347,14 +347,14 @@ describe 'accounts invoke', unless: UNSUPPORTED_PLATFORMS.include?(os[:family]) 
           set_hieradata_on(host, hd_custom_group_name)
           apply_manifest_on(host, pp_manifest, catch_failures: true)
 
-          expect(user('cuser')).to exist
-          expect(user('cuser')).to belong_to_group 'staff'
-          expect(user('cuser')).to have_home_directory '/test/cuser'
+          expect(user('first.last')).to exist
+          expect(user('first.last')).to belong_to_group 'staff'
+          expect(user('first.last')).to have_home_directory '/test/first.last'
 
-          expect(file('/test/cuser')).to be_directory
-          expect(file('/test/cuser')).to be_mode 700
-          expect(file('/test/cuser')).to be_owned_by 'cuser'
-          expect(file('/test/cuser')).to be_grouped_into 'staff'
+          expect(file('/test/first.last')).to be_directory
+          expect(file('/test/first.last')).to be_mode 700
+          expect(file('/test/first.last')).to be_owned_by 'first.last'
+          expect(file('/test/first.last')).to be_grouped_into 'staff'
         end
       end
     end
@@ -476,7 +476,7 @@ describe 'accounts invoke', unless: UNSUPPORTED_PLATFORMS.include?(os[:family]) 
           expect(file('/home/duplicate_user1')).not_to exist
           expect(file('/home/duplicate_user2')).not_to exist
           expect(user('hunner')).not_to exist
-          expect(user('cuser')).not_to exist
+          expect(user('first.last')).not_to exist
           expect(user('grp_flse')).not_to exist
           expect(user('grp_true')).not_to exist
           expect(user('ignore_user')).not_to exist

--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -64,12 +64,12 @@ PUPPETCODE
 pp_custom_group_name = <<-PUPPETCODE
   file { '/test':
     ensure => directory,
-    before => Accounts::User['cuser'],
+    before => Accounts::User['first.last'],
   }
-  accounts::user { 'cuser':
+  accounts::user { 'first.last':
     group                => 'staff',
     password             => '!!',
-    home                 => '/test/cuser',
+    home                 => '/test/first.last',
     home_mode            => '0700',
   }
 PUPPETCODE
@@ -242,14 +242,14 @@ describe 'accounts::user define', unless: UNSUPPORTED_PLATFORMS.include?(os[:fam
     it 'creates group of matching names, assigns non-matching group, manages homedir' do
       apply_manifest(pp_custom_group_name, catch_failures: true)
 
-      expect(user('cuser')).to exist
-      expect(user('cuser')).to belong_to_group 'staff'
-      expect(user('cuser')).to have_home_directory '/test/cuser'
+      expect(user('first.last')).to exist
+      expect(user('first.last')).to belong_to_group 'staff'
+      expect(user('first.last')).to have_home_directory '/test/first.last'
 
-      expect(file('/test/cuser')).to be_directory
-      expect(file('/test/cuser')).to be_mode 700
-      expect(file('/test/cuser')).to be_owned_by 'cuser'
-      expect(file('/test/cuser')).to be_grouped_into 'staff'
+      expect(file('/test/first.last')).to be_directory
+      expect(file('/test/first.last')).to be_mode 700
+      expect(file('/test/first.last')).to be_owned_by 'first.last'
+      expect(file('/test/first.last')).to be_grouped_into 'staff'
     end
   end
 

--- a/spec/type_aliases/user_name_spec.rb
+++ b/spec/type_aliases/user_name_spec.rb
@@ -6,7 +6,7 @@ describe 'Accounts::User::Name' do
       'a',
       '_',                                # Technically allowed but probably shouldn't be.
       'bravo',
-      'charlie-99-delta',                 # Can contain dashes and digits.
+      'charlie-99.delta',                 # Can contain dashes, digits, and dots.
       'echo123',
       'foxtrot$',                         # Can end in a dollar-sign
       '_golf_321_$',
@@ -21,10 +21,12 @@ describe 'Accounts::User::Name' do
   describe 'Invalid user name values' do
     [
       '1-bad-dude',                           # Cannot begin with a digit.
+      '.hidden',                              # Cannot begin with a period.
       '$money',                               # Cannot begin with a dollar-sign.
       '-kilroy_was_here-',                    # Cannot begin with a dash.
       'CamelCase',                            # Cannot contain upper-case letters.
       'more-$-and-cents',                     # Cannot have a dollar-sign in the middle.
+      'fred.',                                # Cannot end in a period.
       'supercalifragilisticexpialiadocious',  # Too long: must be 1-32 chars.
       '',                                     # Cannot be empty.
       5,                                      # Or a non-string.

--- a/types/user/name.pp
+++ b/types/user/name.pp
@@ -2,5 +2,8 @@
 # with a lower case letter or an underscore, followed by lower case letters,
 # digits, underscores, or dashes. They can end with a dollar sign.
 # Usernames may only be up to 32 characters long.
+#
+# Some installations also allow periods, for example to separate first and
+# last names.
 
-type Accounts::User::Name = Pattern[/\A[a-z_][a-z0-9_-]{0,30}[a-z0-9_$-]?\z/]
+type Accounts::User::Name = Pattern[/\A[a-z_]([a-z.0-9_-]{0,30}[a-z0-9_$-])?\z/]


### PR DESCRIPTION
As requested:
> [JakeZ](https://puppetcommunity.slack.com/team/UH3CRT4V7)
> So I suppose it would be bad form to allow usernames that have a `.` in it according to your note on https://github.com/puppetlabs/puppetlabs-accounts/blob/master/types/user/name.pp
> ie: `user.name`, `first.last`, `robert.vincent`
>
> [Robert Vincent](https://puppetcommunity.slack.com/team/UHUQB94QM)
> Thus saith Ubuntu, anyway.
>
> [JakeZ](https://puppetcommunity.slack.com/team/UH3CRT4V7)
> that is unfortunate as 95% of ours are the `.` syntax