### PR TITLE
(maint) Unmanage .travis.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,7 +26,7 @@ GetText:
 GetText/DecorateString:
   Description: We don't want to decorate test output.
   Exclude:
-  - spec/*
+  - spec/**/*
 RSpec/BeforeAfterAll:
   Description: Beware of using after(:all) as it may cause state to leak between tests.
     A necessary evil in acceptance testing.

--- a/.sync.yml
+++ b/.sync.yml
@@ -14,14 +14,7 @@
       - rubocop-rspec
 
 .travis.yml:
-  docker_sets:
-    - set: docker/centos-7
-    - set: docker/ubuntu-14.04
-  docker_defaults:
-    bundler_args: ""
-  secure: ""
-  branches:
-    - release
+  unmanaged: true
 
 appveyor.yml:
   delete: true

--- a/metadata.json
+++ b/metadata.json
@@ -83,6 +83,6 @@
     }
   ],
   "template-url": "https://github.com/puppetlabs/pdk-templates#master",
-  "template-ref": "heads/master-0-g7827fc2",
+  "template-ref": "heads/master-0-g7b1d6ae",
   "pdk-version": "1.10.0"
 }


### PR DESCRIPTION
.travis.yml now used by litmus. As such it should not be managed by
pdk-templates.