### PR TITLE
MODULES-9447 -- Narrow dependency between removed user and group.

### DIFF
--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -245,7 +245,7 @@ define accounts::user (
       }
     }
     # End workaround.
-    User[$name] -> Group <| |>
+    User[$name] -> Group <| ensure == 'absent' |>
     if $create_group {
       # Only remove the group if it is the same as user name as it may be shared.
       if $name == $group {


### PR DESCRIPTION
[(MODULES-9447)](https://tickets.puppetlabs.com/browse/MODULES-9447)  Unfortunately, we still have some issues with dependency cycles when removing accounts.

[This line](https://github.com/puppetlabs/puppetlabs-accounts/blob/master/manifests/user.pp#L248) was added to ensure that we don't remove a user's primary group before removing a user:

```
User[$name] -> Group <| |>
```

This causes a dependency cycle whenever any code in the same run requires any group, and must run before the user is deleted.  For instance, if an exec is used to backup a homedir before deletion, and the exec is run as user and group root, then a dependency cycle is created.

At a minimum, the dependency should be narrowed to:

```
User[$name] -> Group <| ensure == 'absent' |>
```

The included acceptance tests fails without the above change, and passes with it.