### PR TITLE
fixed typo: manage_home shoud be managehome

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,8 @@ accounts::group_list:
   users:  {}
 accounts::user_defaults:
   groups: [ 'users' ]
-  manage_home: true
-  system:      false
+  managehome: true
+  system:     false
 accounts::user_list:
   admin:
     groups: ['admins', 'users']


### PR DESCRIPTION
The hiera example in the README is broken as it should read "managehome" not "manage_home".