### PR TITLE
(MODULES-9712) Move data into hiera.

### DIFF
--- a/data/Debian.yaml
+++ b/data/Debian.yaml
@@ -1,0 +1,5 @@
+---
+
+accounts::user::defaults::home_template: '/home/%s'
+accounts::user::defaults::locked_shell: '/usr/sbin/nologin'
+accounts::user:;defaults::root_home: '/root'

--- a/data/Solaris.yaml
+++ b/data/Solaris.yaml
@@ -1,0 +1,5 @@
+---
+
+accounts::user::defaults::home_template: '/export/home/%s'
+accounts::user::defaults::locked_shell: '/usr/bin/false'
+accounts::user::defaults::root_home: '/'

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,11 @@
+---
+
+version: 5
+
+defaults:
+  data_hash: 'yaml_data'
+  datadir: 'data'
+
+hierarchy:
+  - name: 'os.family'
+    path: '%{facts.os.family}.yaml'

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -216,16 +216,12 @@ define accounts::user (
 
   assert_type(Accounts::User::Name, $name)
 
+  include accounts::user::defaults
+
   $_home = $home ? {
     undef => $name ? {
-      'root' => $facts['os']['family'] ? {
-        'Solaris' => '/',
-        default   => '/root',
-      },
-      default => $facts['os']['family'] ? {
-        'Solaris' => "/export/home/${name}",
-        default   => "/home/${name}",
-      },
+      'root'  => $accounts::user::defaults::root_home,
+      default => $accounts::user::defaults::home_template.sprintf($name),
     },
     default => $home,
   }
@@ -296,11 +292,7 @@ define accounts::user (
       default => $purge_sshkeys,
     }
     $_shell = $locked ? {
-      true => $facts['os']['family'] ? {
-        'Debian'  => '/usr/sbin/nologin',
-        'Solaris' => '/usr/bin/false',
-        default   => '/sbin/nologin',
-      },
+      true    => $accounts::user::defaults::locked_shell,
       default => $shell,
     }
     user { $name:

--- a/manifests/user/defaults.pp
+++ b/manifests/user/defaults.pp
@@ -1,0 +1,21 @@
+# @summary
+#   Load some user defaults from hiera data.
+#
+# @param home_template
+#   The sprintf template used to determine a user's home directory.
+#
+# @param locked_shell
+#   The shell assigned to locked user accounts.
+#
+# @param root_home
+#   The home directory of the root user.
+#
+class accounts::user::defaults (
+  Stdlib::AbsolutePath      $home_template = '/home/%s',
+  Stdlib::AbsolutePath      $locked_shell = '/sbin/nologin',
+  Stdlib::AbsolutePath      $root_home = '/root',
+)
+{
+  # Nothing to see here; move along.
+}
+

--- a/manifests/user/defaults.pp~
+++ b/manifests/user/defaults.pp~
@@ -1,0 +1,12 @@
+# @summary
+#   Load some user defaults from hiera data.
+#
+# @param home_template
+#   The sprintf template used to determine a user's home directory.
+#
+# @param locked_shell
+#   The shell assigned to locked user accounts.
+#
+# @param root_home
+#   The home directory of the root user.
+

--- a/types/group/hash.pp
+++ b/types/group/hash.pp
@@ -1,3 +1,7 @@
+# Group resoureces hash.
+# @summary A hash of group resources, keyed by group name.
+# Passed as the second parameter of the ensure_resources function.
+#
 type Accounts::Group::Hash = Hash[
   Accounts::User::Name, Accounts::Group::Resource
 ]

--- a/types/group/provider.pp
+++ b/types/group/provider.pp
@@ -1,3 +1,8 @@
+# Group provider.
+# @summary The specific backend to use for this group resource.
+# You will seldom need to specify this -- Puppet will usually discover the
+# appropriate provider for your platform.
+#
 type Accounts::Group::Provider = Enum[
   'aix',
   'directoryservice',

--- a/types/group/resource.pp
+++ b/types/group/resource.pp
@@ -1,3 +1,7 @@
+# Group attributes hash.
+# @summary A hash of group attributes.
+# Passed as the third parameter of the ensure_resources function.
+#
 type Accounts::Group::Resource = Struct[
   { Optional[ensure]          => Enum['absent', 'present'],
     Optional[allowdupe]       => Boolean,

--- a/types/user/expiry.pp
+++ b/types/user/expiry.pp
@@ -1,5 +1,7 @@
-# Account expiration is either 'absent' or a YYYY-MM-DD datestring.
-
+# Account expiration date.
+# @summary Account access will be denied after this date.
+# Either 'absent' or a YYYY-MM-DD datestring.
+#
 type Accounts::User::Expiry = Variant[
   Enum['absent'],
   Pattern[/\A(19|[2-9]\d)\d\d-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])\z/]

--- a/types/user/hash.pp
+++ b/types/user/hash.pp
@@ -1,3 +1,7 @@
+# User resources hash.
+# @summary A hash of user resources, keyed by user name.
+# Passed as the second parameter of the ensure_resources function.
+#
 type Accounts::User::Hash = Hash[
   Accounts::User::Name, Accounts::User::Resource
 ]

--- a/types/user/iterations.pp
+++ b/types/user/iterations.pp
@@ -1,4 +1,9 @@
+# Password hash iterations.
+# @summary Chained computation iterations for the PBKDF2 password hash.
+# This parameter is used in OS X, and is required for managing passwords
+# on OS X 10.8 and newer.
+#
 type Accounts::User::Iterations = Variant[
   Integer[1,],
-  Pattern[/\A[1-9]\d*\z/]
+  Pattern[/\A[1-9]\d*\z/],
 ]

--- a/types/user/name.pp
+++ b/types/user/name.pp
@@ -1,9 +1,11 @@
-# From useradd(8): It is usually recommended to only use usernames that begin
-# with a lower case letter or an underscore, followed by lower case letters,
-# digits, underscores, or dashes. They can end with a dollar sign.
+# Account (user or group) name.
+# @summary Each user or group should have a unique alphanumeric name.
+# From useradd(8): It is usually recommended to only use usernames
+# that begin with a lower case letter or an underscore, followed by lower case 
+# letters, digits, underscores, or dashes. They can end with a dollar sign.
 # Usernames may only be up to 32 characters long.
 #
 # Some installations also allow periods, for example to separate first and
 # last names.
-
+#
 type Accounts::User::Name = Pattern[/\A[a-z_]([a-z.0-9_-]{0,30}[a-z0-9_$-])?\z/]

--- a/types/user/passwordmaxage.pp
+++ b/types/user/passwordmaxage.pp
@@ -1,4 +1,6 @@
-# Maximum days between password changes. On most systems, the default value of
-# 99999 is about 274 years, which effectively disables password aging.
-
+# Max password age.
+# @summary Maximum days between password changes.
+# On most systems, the default value of 99999 is about 274 years, which
+# effectively disables password aging.
+#
 type Accounts::User::PasswordMaxAge = Integer[1, 99999]

--- a/types/user/resource.pp
+++ b/types/user/resource.pp
@@ -1,3 +1,7 @@
+# User attributes hash.
+# @summary A hash of user attributes.
+# Passed as the third parameter of the ensure_resources function.
+#
 type Accounts::User::Resource = Struct[
   { Optional[ensure]                   => Enum['absent','present'],
     Optional[allowdupe]                => Boolean,

--- a/types/user/uid.pp
+++ b/types/user/uid.pp
@@ -1,5 +1,7 @@
-# On most Unix systems, the highest uid is 2^32 - 1, or 4294967295
-
+# Numeric user ID.
+# @summary Each user on a system should have a unique numeric uid.
+# On most Unix systems, the highest uid is 2^32 - 1, or 4294967295.
+#
 type Accounts::User::Uid = Variant[
   Integer[0,4294967295],
   Pattern[/\A0\z/,


### PR DESCRIPTION
Current best-practice is to move os-specific data from manifests into hiera.

Fixes [MODULES-9712](https://tickets.puppetlabs.com/browse/MODULES-9712).