### PR TITLE
fix problematic parsing of keyspec

### DIFF
--- a/manifests/manage_keys.pp
+++ b/manifests/manage_keys.pp
@@ -26,7 +26,7 @@ define accounts::manage_keys(
   Accounts::User::Name     $key_owner = $user,
 ) {
 
-  $key_def = $keyspec.match(/^((.*)\s+)?((ssh|ecdsa-sha2).*)\s+(.*)\s+(.*)$/)
+  $key_def = $keyspec.match(/^(([^\s]*)\s+)?((ssh|ecdsa-sha2)[^\s]*)\s+([^\s]*)\s+(.*)$/)
   if (! $key_def) {
     err(translate("Could not interpret SSH key definition: '%{keyspec}'", {'keyspec' => $keyspec}))
   }


### PR DESCRIPTION
The original had some flaws. The `.*` statement is an eager match and could eat spaces. An example:

`options ssh-xyz key name with spaces` would be matched as:

```
[
  "options ",
  "options",
  "ssh-xyz key name",
  "ssh",
  "with",
  "spaces"
]
```

The new regex would match it like this:
```
[
  "options ",
  "options",
  "ssh-xyz",
  "ssh",
  "key",
  "name with spaces"
]
```

Another example: `ssh-xyz key ssh name with spaces`
```
[
  "ssh-xyz key ",
  "ssh-xyz key",
  "ssh name",
  "ssh",
  "with",
  "spaces"
]
```
vs
```
[
  "",
  "",
  "ssh-xyz",
  "ssh",
  "key",
  "ssh name with spaces"
]
```

Workaround until a fix is released: carefully manage the spaces and do not use `ssh` or `ecdsa-sha2` in unexpected places (certainly no spaces in the name).

Thanks to @ekoster for finding this.