### PR TITLE
Use user group instead of user name for sshkey owner group

### DIFF
--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -207,7 +207,7 @@ define accounts::user (
   Optional[String]                         $salt                     = undef,
   Optional[Stdlib::Unixpath]               $shell                    = '/bin/bash',
   Optional[Stdlib::Unixpath]               $sshkey_custom_path       = undef,
-  Optional[Accounts::User::Name]           $sshkey_group             = $name,
+  Optional[Accounts::User::Name]           $sshkey_group             = $group,
   Optional[Accounts::User::Name]           $sshkey_owner             = $name,
   Array[String]                            $sshkeys                  = [],
   Boolean                                  $system                   = false,


### PR DESCRIPTION
If a group with a different name than the username is passed, the group with the default name does not exist.