### PR TITLE
Allow substitution in accounts::key_management::sshkey_custom_path param.

### DIFF
--- a/manifests/key_management.pp
+++ b/manifests/key_management.pp
@@ -47,7 +47,7 @@ define accounts::key_management(
   }
 
   if $sshkey_custom_path != undef {
-    $key_file = $sshkey_custom_path
+    $key_file = $sshkey_custom_path.sprintf($user)
   } elsif $user_home {
     $key_file = "${sshkey_dotdir}/authorized_keys"
   } else {


### PR DESCRIPTION
Fixes: [MODULES-9978](https://tickets.puppetlabs.com/browse/MODULES-9978)

