### PR TITLE
MODULES-10550 fix keyspec parsing to allow whitespaces in options and…

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,8 @@
 fixtures:
   repositories:
+    sshkeys_core:
+      repo: 'https://github.com/puppetlabs/puppetlabs-sshkeys_core'
+      puppet_version: '>= 6.0.0'
     stdlib:
       repo: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
       ref: '5.0.0'

--- a/lib/puppet/functions/accounts_ssh_authorized_keys_line_parser.rb
+++ b/lib/puppet/functions/accounts_ssh_authorized_keys_line_parser.rb
@@ -1,0 +1,22 @@
+# Parse an ssh authorized_keys line string into an array using its expected
+# pattern by using a combination of regex matching and extracting the substring
+# before the match as ssh-options. This allows whitespaces inside the options
+# and inside the comment and is consistent with the behavior of openssh.
+# The returned options element can by an empty string.
+Puppet::Functions.create_function(:accounts_ssh_authorized_keys_line_parser) do
+  # @param str ssh authorized_keys line string
+  # @return [Array] of authroized_keys_line components:
+  #   ['options','keytype','key','comment']
+  # @example Calling the function
+  #   accounts_ssh_authorized_keys_line_parser_string('options ssh-rsa AAAA... comment)
+  dispatch :accounts_ssh_authorized_keys_line_parser_string do
+    param 'String', :str
+  end
+
+  def accounts_ssh_authorized_keys_line_parser_string(str)
+    matched = str.match(%r{((ssh-|ecdsa-)[^\s]+)\s+([^\s]+)\s+(.*)$})
+    raise ArgumentError, 'Wrong Keyline format!' unless matched && matched.length == 5
+    options = str[0, str.index(matched[0])].rstrip
+    [options, matched[1], matched[3], matched[4]]
+  end
+end

--- a/manifests/manage_keys.pp
+++ b/manifests/manage_keys.pp
@@ -26,19 +26,19 @@ define accounts::manage_keys(
   Accounts::User::Name     $key_owner = $user,
 ) {
 
-  $key_def = $keyspec.match(/^(([^\s]*)\s+)?((ssh|ecdsa-sha2)[^\s]*)\s+([^\s]*)\s+(.*)$/)
+  $key_def = accounts_ssh_authorized_keys_line_parser($keyspec)
   if (! $key_def) {
     err(translate("Could not interpret SSH key definition: '%{keyspec}'", {'keyspec' => $keyspec}))
   }
   else {
-    if ($key_def[2]) {
-      $key_options = accounts_ssh_options_parser($key_def[2])
+    if (! empty($key_def[0])) {
+      $key_options = accounts_ssh_options_parser($key_def[0])
     } else {
       $key_options = undef
     }
-    $key_type    = $key_def[3]
-    $key_content = $key_def[5]
-    $key_name    = $key_def[6]
+    $key_type    = $key_def[1]
+    $key_content = $key_def[2]
+    $key_name    = $key_def[3]
 
     $key_title = "${user}_${key_type}_${key_name}"
 

--- a/spec/defines/accounts_user_spec.rb
+++ b/spec/defines/accounts_user_spec.rb
@@ -60,7 +60,9 @@ describe 'accounts::user' do
               password_max_age: 60,
               shell:            '/bin/csh',
               sshkey_owner:     'dan',
-              sshkeys:          ['1 2 3', '2 3 4'],
+              sshkeys:          ['ssh-rsa AAAAB3Nza...LiPk== dan@example1.net',
+                                 'permitopen="192.0.2.1:80",permitopen="192.0.2.2:25" ssh-dss AAAAB5...21S== dan key2',
+                                 'command="/bin/echo Hello World",from="myhost.exapmle.com,192.168.1.1" ecdsa-sha2-nistp521 test_key vagrant2'],
               uid:              123,
             }
           end

--- a/spec/functions/accounts_ssh_authorized_keys_line_parser_spec.rb
+++ b/spec/functions/accounts_ssh_authorized_keys_line_parser_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe 'accounts_ssh_authorized_keys_line_parser' do
+  it {
+    is_expected.not_to eq(nil)
+  }
+  it {
+    is_expected.to run.with_params('').and_raise_error(ArgumentError, %r{Wrong Keyline format!})
+  }
+  it {
+    is_expected.to run.with_params('options unknown-keytype key comment').and_raise_error(ArgumentError, %r{Wrong Keyline format!})
+  }
+  it {
+    is_expected.to run.with_params('ssh-xyz key name with spaces').and_return( \
+      ['', 'ssh-xyz', 'key', 'name with spaces'],
+    )
+  }
+  it {
+    is_expected.to run.with_params('"options with arguments",moreoptions,"moreoptions with arguments" ecdsa-xyz key name with spaces').and_return( \
+      ['"options with arguments",moreoptions,"moreoptions with arguments"', 'ecdsa-xyz', 'key', 'name with spaces'],
+    )
+  }
+  it {
+    is_expected.to run.with_params('tunnel="0",command="sh /etc/netstart tun0" ssh-rsa AAAA...== jane@example.net').and_return( \
+      ['tunnel="0",command="sh /etc/netstart tun0"', 'ssh-rsa', 'AAAA...==', 'jane@example.net'],
+    )
+  }
+  it {
+    # rubocop:disable Metrics/LineLength
+    is_expected.to run.with_params('command="rsync --server --sender -vlHogtpr --numeric-ids . /",from="192.168.1.1",no-port-forwarding,no-X11-forwarding,no-agent-forwarding ecdsa-sha2-nistp384 AAAA...= rsync backup').and_return( \
+      ['command="rsync --server --sender -vlHogtpr --numeric-ids . /",from="192.168.1.1",no-port-forwarding,no-X11-forwarding,no-agent-forwarding', 'ecdsa-sha2-nistp384', 'AAAA...=', 'rsync backup'],
+    )
+    # rubocop:enable Metrics/LineLength
+  }
+end


### PR DESCRIPTION
… comments

move parsing of the keyspec param to a new ruby function
accounts_ssh_authorized_keys_line_parser.rb and change manage_keys.pp to use
that function to fix issues with whitespaces inside the options part.

Uses the relatively well defined "keytype" to anchor the match instead
of trying to squeeze the whole keyspec line into one regex (which causes several
issues discussed in the pull request for 59ce4f8f). Gets the options from
an rstriped substring derived from the position of the match.
The new parsing works with whitespaces inside both, the options and the comment
part of a keyspec and behaves more similar to openssh itself now.

Some limitations discussed in the pr for 59ce4f8f still remain:· e.g. strings
like 'ssh-' or 'ecdsh-' inside the options or comment could still break the
parsing.

Updates tests in accounts_user_spec.rb to contain more meaningful checks as
the new parser wouldn't accept the old simplified keyspecs '1 2 3' and '2 3 4'

Introduces spec tests for the new parser containing a few complex examples
taken from pr 59ce4f8f discussion, the authorized_keys manpage and the wild