### PR TITLE
(IAC-686) Tagging tests and creating setups for integration testing

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -8,6 +8,8 @@ fixtures:
       ref: '5.0.0'
     translate:
       repo: 'https://github.com/puppetlabs/puppetlabs-translate'
+    puppet_conf:
+      repo: 'https://github.com/puppetlabs/puppet_conf.git'
     facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'
     puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
     provision: 'https://github.com/puppetlabs/provision.git'

--- a/.sync.yml
+++ b/.sync.yml
@@ -58,7 +58,16 @@ Gemfile:
     - gem: puppet-lint-i18n
 Rakefile:
   requires:
-  - puppet_pot_generator/rake_tasks
+    - puppet_pot_generator/rake_tasks
+  extras:
+    - |
+      require 'rspec/core/rake_task'
+      namespace :accounts do
+        RSpec::Core::RakeTask.new(:integration) do |t|
+          t.pattern = 'spec/acceptance/**{,/*/**}/*_spec.rb'
+          t.rspec_opts = "--tag integration"
+        end
+      end
 spec/spec_helper.rb:
   mock_with: ":rspec"
   coverage_report: true

--- a/Rakefile
+++ b/Rakefile
@@ -87,3 +87,10 @@ EOM
   end
 end
 
+require 'rspec/core/rake_task'
+namespace :accounts do
+  RSpec::Core::RakeTask.new(:integration) do |t|
+    t.pattern = 'spec/acceptance/**{,/*/**}/*_spec.rb'
+    t.rspec_opts = "--tag integration"
+  end
+end

--- a/plans/pe_server_setup.pp
+++ b/plans/pe_server_setup.pp
@@ -1,0 +1,16 @@
+plan accounts::pe_server_setup(
+) {
+  $pe_server =  get_targets('*').filter |$n| { $n.vars['role'] == 'master' }
+  # install pe server
+  run_task('provision::install_pe', $pe_server)
+
+  # install the module
+  run_command('puppet module install puppetlabs-accounts', $pe_server)
+
+  # set the ui password
+  run_command('puppet infra console_password --password=litmus', $pe_server)
+
+  # work around for pe's module structure, for the UI
+  run_command('ln -s /etc/puppetlabs/code/environments/production/modules/puppetlabs-accounts /opt/puppetlabs/puppet/modules', $pe_server)
+  run_command('ln -s /etc/puppetlabs/code/environments/production/modules/ruby_task_helper /opt/puppetlabs/puppet/modules', $pe_server)
+}

--- a/plans/provision_machines.pp
+++ b/plans/provision_machines.pp
@@ -1,0 +1,8 @@
+plan accounts::provision_machines(
+  Optional[String] $pe_master = 'centos-7-x86_64',
+  Optional[String] $agent = 'centos-7-x86_64',
+) {
+  # provision server machine, set role
+  run_task('provision::abs', 'localhost', action => 'provision', platform => $pe_master, inventory => './', vars => 'role: master')
+  run_task('provision::abs', 'localhost', action => 'provision', platform => $agent, inventory => './', vars => 'role: agent')
+}

--- a/plans/puppet_agents_setup.pp
+++ b/plans/puppet_agents_setup.pp
@@ -1,0 +1,15 @@
+plan accounts::puppet_agents_setup(
+) {
+  # get pe_server ?
+  $server = get_targets('*').filter |$n| { $n.vars['role'] == 'master' }
+
+  # get agents ?
+  $agents = get_targets('*').filter |$n| { $n.vars['role'] != 'master' }
+
+  # install agents
+  run_task('puppet_agent::install', $agents)
+
+  # set the server
+  $server_string = $server[0].name
+  run_task('puppet_conf', $agents, action => 'set', section => 'main', setting => 'server', value => $server_string)
+}

--- a/spec/acceptance/accounts_spec.rb
+++ b/spec/acceptance/accounts_spec.rb
@@ -307,7 +307,7 @@ describe 'accounts invoke', unless: UNSUPPORTED_PLATFORMS.include?(os[:family]) 
     end
   end
 
-  describe 'main tests' do
+  describe 'main tests', :integration do
     it 'creates groups of matching names, assigns non-matching group, '\
         'manages homedir, manages other properties, gives key, '\
         'makes dotfiles, managevim false' do


### PR DESCRIPTION
Steps to run tests in integration environment.
Plans are created for  provisioning master and agent node.
Roles created for master with plans. spec_helper_acceptance will identify the master node and run tests against the node.

```bundle install
bundle exec rake spec_prep 
bundle exec bolt --modulepath spec/fixtures/modules plan run accounts::provision_machines 
bundle exec bolt --modulepath spec/fixtures/modules -i ./inventory.yaml plan run accounts::pe_server_setup 
bundle exec bolt --modulepath spec/fixtures/modules -i ./inventory.yaml plan run accounts::puppet_agents_setup 
bundle exec rake accounts:integration 
bundle exec rake litmus:tear_down
```

Integration test results

![Screenshot 2020-08-20 at 12 18 55](https://user-images.githubusercontent.com/20660680/90763854-56cbc280-e2df-11ea-9c77-23020de679c9.png)

Acceptance tests results

![Screenshot 2020-08-20 at 12 18 29](https://user-images.githubusercontent.com/20660680/90763865-5d5a3a00-e2df-11ea-9fea-5107e3227b05.png)


ToDo
Since the plans are same across on most of the modules. We can add them to provision repo