### PR TITLE
Allow for Sensitive type passwords in accounts::user

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -368,7 +368,7 @@ Name of the user.
 
 ##### `password`
 
-Data type: `String`
+Data type: `Variant[String, Sensitive[String]]`
 
 The user's password, in whatever encrypted format the local machine
 requires. Default: '!!', which prevents the user from logging in with a

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -200,7 +200,7 @@ define accounts::user (
   Boolean                                  $managehome               = true,
   Boolean                                  $managevim                = true,
   Enum['inclusive','minimum']              $membership               = 'minimum',
-  String                                   $password                 = '!!',
+  Variant[String, Sensitive[String]]       $password                 = '!!',
   Optional[Accounts::User::PasswordMaxAge] $password_max_age         = undef,
   Boolean                                  $purge_sshkeys            = false,
   Boolean                                  $purge_user_home          = false,
@@ -283,7 +283,7 @@ define accounts::user (
         }
       )
     }
-    $_password = ($password == '' and $ignore_password_if_empty) ? {
+    $_password = (($password =~ String and $password == '') and $ignore_password_if_empty) ? {
       true    => undef,
       default => $password,
     }

--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -200,6 +200,12 @@ pp_user_with_duplicate_uid = <<-PUPPETCODE
   }
 PUPPETCODE
 
+pp_user_with_sensitive_password = <<-PUPPETCODE
+  accounts::user { 'sensitive_user':
+    password => Sensitive('bar'),
+  }
+PUPPETCODE
+
 pp_cleanup = <<-PUPPETCODE
   file { '/test':
     ensure  => 'absent',
@@ -358,6 +364,14 @@ describe 'accounts::user define', unless: UNSUPPORTED_PLATFORMS.include?(os[:fam
 
       expect(user('duplicate_user2')).to exist
       expect(user('duplicate_user2')).to have_uid 1234
+    end
+  end
+  describe 'allow password to be a Sentitive type' do
+    it 'runs with no errors' do
+      apply_manifest(pp_user_with_sensitive_password, catch_failures: true)
+
+      expect(user('sensitive_user')).to exist
+      expect(user('sensitive_user')).to contain_password 'bar'
     end
   end
 end

--- a/spec/defines/accounts_user_spec.rb
+++ b/spec/defines/accounts_user_spec.rb
@@ -187,6 +187,14 @@ describe 'accounts::user' do
           it { is_expected.to contain_user(title).with('salt'       => params[:salt]) }
         end
 
+        describe 'when using a sensitive password' do
+          let(:params) do
+            { password: RSpec::Puppet::RawString.new("Sensitive('foo')") }
+          end
+
+          it { is_expected.to contain_user(title).with('password' => 'foo') }
+        end
+
         describe 'when supplying resource defaults' do
           let(:params) { {} }
           let(:pre_condition) { "Accounts::User{ shell => '/bin/zsh' }" }


### PR DESCRIPTION
This PR adds the capability of passing in a Sensitive type `password` parameter to the `accounts::user` resource. The `user` resource already accepts the Sensitive type, so its a small change.