### PR TITLE
(maint) - Update to wrap unit test return value in sensitive wrapper

### DIFF
--- a/spec/defines/accounts_user_spec.rb
+++ b/spec/defines/accounts_user_spec.rb
@@ -192,7 +192,7 @@ describe 'accounts::user' do
             { password: RSpec::Puppet::RawString.new("Sensitive('foo')") }
           end
 
-          it { is_expected.to contain_user(title).with('password' => 'foo') }
+          it { is_expected.to contain_user(title).with('password' => sensitive('foo')) }
         end
 
         describe 'when supplying resource defaults' do


### PR DESCRIPTION
As of rspec-puppet 2.8.0 support has been added for the `Sensitive` data type. With this change when checking sensitive values they should be wrapped within the new sensitive helper, i.e.:
`it { is_expected.to contain_user(title).with('password' => sensitive('foo')) }`