### PR TITLE
(MODULES-10867) Ensure ssh key name is unique based on type, content and description

### DIFF
--- a/manifests/manage_keys.pp
+++ b/manifests/manage_keys.pp
@@ -39,7 +39,7 @@ define accounts::manage_keys(
     $key_type    = $key_def[1]
     $key_content = $key_def[2]
     $key_md5     = md5($key_def[2])
-    $key_name    = "${key_def[3]}-$key_md5}"
+    $key_name    = "${key_def[3]}-${key_md5}"
 
     $key_title = "${user}_${key_type}_${key_name}"
 

--- a/manifests/manage_keys.pp
+++ b/manifests/manage_keys.pp
@@ -39,7 +39,7 @@ define accounts::manage_keys(
     $key_type    = $key_def[1]
     $key_content = $key_def[2]
     $key_md5     = md5($key_def[2])
-    $key_name    = "${key_def[3]}-${key_md5}"
+    $key_name    = "${key_def[3]}_${key_md5}"
 
     $key_title = "${user}_${key_type}_${key_name}"
 

--- a/manifests/manage_keys.pp
+++ b/manifests/manage_keys.pp
@@ -38,7 +38,8 @@ define accounts::manage_keys(
     }
     $key_type    = $key_def[1]
     $key_content = $key_def[2]
-    $key_name    = $key_def[3]
+    $key_md5     = md5($key_def[2])
+    $key_name    = "${key_def[3]}-$key_md5}"
 
     $key_title = "${user}_${key_type}_${key_name}"
 

--- a/spec/defines/accounts_user_spec.rb
+++ b/spec/defines/accounts_user_spec.rb
@@ -82,9 +82,9 @@ describe 'accounts::user' do
                                                                           'mode' => params[:home_mode])
           end
           it { is_expected.to contain_accounts__key_management("#{title}_key_management").with('sshkeys' => params[:sshkeys]) }
-          it { is_expected.to contain_ssh_authorized_key("#{params[:sshkey_owner]}_ssh-rsa_dan@example1.net_1e44b207704970cf4acb3470331b0e5c")}
-          it { is_expected.to contain_ssh_authorized_key("#{params[:sshkey_owner]}_ssh-dss_dan key2_6e9b8958712502a8b31e1c283b6e6fce")}
-          it { is_expected.to contain_ssh_authorized_key("#{params[:sshkey_owner]}_ecdsa-sha2-nistp521_vagrant2_8c32d1183251df9828f929b935ae0419")}
+          it { is_expected.to contain_ssh_authorized_key("#{params[:sshkey_owner]}_ssh-rsa_dan@example1.net_1e44b207704970cf4acb3470331b0e5c") }
+          it { is_expected.to contain_ssh_authorized_key("#{params[:sshkey_owner]}_ssh-dss_dan key2_6e9b8958712502a8b31e1c283b6e6fce") }
+          it { is_expected.to contain_ssh_authorized_key("#{params[:sshkey_owner]}_ecdsa-sha2-nistp521_vagrant2_8c32d1183251df9828f929b935ae0419") }
           it { is_expected.to contain_file("#{params[:home]}/.ssh") }
         end
 


### PR DESCRIPTION
Allow multiple ssh keys of the same type having the same description.