### PR TITLE
(maint) Remove RHEL 5 family support; clean up OS names in metadata.json

### DIFF
--- a/provision.yaml
+++ b/provision.yaml
@@ -1,32 +1,99 @@
 ---
 default:
   provisioner: docker
-  images: ['litmusimage/centos:7']
+  images:
+  - litmusimage/centos:7
 vagrant:
   provisioner: vagrant
-  images: ['centos/7', 'generic/ubuntu1804']
+  images:
+  - centos/7
+  - generic/ubuntu1804
 travis_deb:
   provisioner: docker
-  images: ['litmusimage/debian:8', 'litmusimage/debian:9', 'litmusimage/debian:10']
+  images:
+  - litmusimage/debian:8
+  - litmusimage/debian:9
+  - litmusimage/debian:10
 travis_ub_5:
   provisioner: docker
-  images: ['litmusimage/ubuntu:14.04', 'litmusimage/ubuntu:16.04', 'litmusimage/ubuntu:18.04']
+  images:
+  - litmusimage/ubuntu:14.04
+  - litmusimage/ubuntu:16.04
+  - litmusimage/ubuntu:18.04
 travis_ub_6:
   provisioner: docker
-  images: ['litmusimage/ubuntu:14.04', 'litmusimage/ubuntu:16.04', 'litmusimage/ubuntu:18.04', 'litmusimage/ubuntu:20.04']
+  images:
+  - litmusimage/ubuntu:14.04
+  - litmusimage/ubuntu:16.04
+  - litmusimage/ubuntu:18.04
+  - litmusimage/ubuntu:20.04
 travis_el6:
   provisioner: docker
-  images: ['centos:6', 'scientificlinux/sl:6']
+  images:
+  - centos:6
+  - scientificlinux/sl:6
 travis_el7:
   provisioner: docker
-  images: ['litmusimage/centos:7', 'litmusimage/oraclelinux:7', 'litmusimage/scientificlinux:7']
+  images:
+  - litmusimage/centos:7
+  - litmusimage/oraclelinux:7
+  - litmusimage/scientificlinux:7
 travis_el8:
   provisioner: docker
-  images: ['litmusimage/centos:8']
+  images:
+  - litmusimage/centos:8
 release_checks_5:
   provisioner: abs
-  images: ['redhat-6-x86_64', 'redhat-7-x86_64', 'redhat-8-x86_64', 'centos-6-x86_64', 'centos-7-x86_64', 'centos-8-x86_64', 'oracle-6-x86_64', 'oracle-7-x86_64', 'scientific-6-x86_64', 'scientific-7-x86_64', 'debian-8-x86_64', 'debian-9-x86_64', 'debian-10-x86_64', 'sles-15-x86_64', 'ubuntu-1404-x86_64', 'ubuntu-1604-x86_64', 'ubuntu-1804-x86_64']
+  images:
+  - redhat-6-x86_64
+  - redhat-7-x86_64
+  - redhat-8-x86_64
+  - centos-6-x86_64
+  - centos-7-x86_64
+  - centos-8-x86_64
+  - oracle-6-x86_64
+  - oracle-7-x86_64
+  - scientific-6-x86_64
+  - scientific-7-x86_64
+  - debian-8-x86_64
+  - debian-9-x86_64
+  - debian-10-x86_64
+  - sles-15-x86_64
+  - ubuntu-1404-x86_64
+  - ubuntu-1604-x86_64
+  - ubuntu-1804-x86_64
 release_checks_6:
   provisioner: abs
-  images: ['redhat-6-x86_64', 'redhat-7-x86_64', 'redhat-8-x86_64', 'centos-6-x86_64', 'centos-7-x86_64', 'centos-8-x86_64', 'oracle-6-x86_64', 'oracle-7-x86_64', 'scientific-6-x86_64', 'scientific-7-x86_64', 'debian-8-x86_64', 'debian-9-x86_64', 'debian-10-x86_64', 'sles-15-x86_64', 'ubuntu-1404-x86_64', 'ubuntu-1604-x86_64', 'ubuntu-1804-x86_64', 'ubuntu-2004-x86_64']
-  
+  images:
+  - redhat-6-x86_64
+  - redhat-7-x86_64
+  - redhat-8-x86_64
+  - centos-6-x86_64
+  - centos-7-x86_64
+  - centos-8-x86_64
+  - oracle-6-x86_64
+  - oracle-7-x86_64
+  - scientific-6-x86_64
+  - scientific-7-x86_64
+  - debian-8-x86_64
+  - debian-9-x86_64
+  - debian-10-x86_64
+  - sles-15-x86_64
+  - ubuntu-1404-x86_64
+  - ubuntu-1604-x86_64
+  - ubuntu-1804-x86_64
+  - ubuntu-2004-x86_64
+release_checks_7:
+  provisioner: abs
+  images:
+  - redhat-7-x86_64
+  - redhat-8-x86_64
+  - centos-7-x86_64
+  - centos-8-x86_64
+  - oracle-7-x86_64
+  - scientific-7-x86_64
+  - debian-9-x86_64
+  - debian-10-x86_64
+  - sles-15-x86_64
+  - ubuntu-1804-x86_64
+  - ubuntu-2004-x86_64


### PR DESCRIPTION
(maint) Remove RHEL 5 family support; Clean up OS naming in metadata.json
pdk version: `1.18.1` 
