### PR TITLE
MODULES-11100 - Add sk-ecdsa public key support, and implement tests for sk-ecdsa and ecdsa keys

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -1,8 +1,6 @@
 name: "Auto release"
 
 on:
-  schedule:
-    - cron: '0 3 * * 6'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,10 +38,10 @@ jobs:
           ref: ${{ github.ref }}
           clean: true
       - name: "PDK Build"
-        uses: docker://puppet/pdk:2.1.0.0
+        uses: docker://puppet/pdk:nightly
         with:
           args: 'build'
       - name: "Push to Forge"
-        uses: docker://puppet/pdk:2.1.0.0
+        uses: docker://puppet/pdk:nightly
         with:
           args: 'release publish --forge-token ${{ secrets.FORGE_API_KEY }} --force'

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -83,6 +83,7 @@ jobs:
     env:
       BUILDEVENT_FILE: '../buildevents.txt'
       PUPPET_GEM_VERSION: ${{ matrix.puppet_version }}
+      FACTER_GEM_VERSION: 'https://github.com/puppetlabs/facter#main'
 
     steps:
       - run: |

--- a/.pdkignore
+++ b/.pdkignore
@@ -27,6 +27,7 @@
 /inventory.yaml
 /spec/fixtures/litmus_inventory.yaml
 /appveyor.yml
+/.editorconfig
 /.fixtures.yml
 /Gemfile
 /.gitattributes

--- a/lib/puppet/functions/accounts_ssh_authorized_keys_line_parser.rb
+++ b/lib/puppet/functions/accounts_ssh_authorized_keys_line_parser.rb
@@ -16,7 +16,7 @@ Puppet::Functions.create_function(:accounts_ssh_authorized_keys_line_parser) do
   end
 
   def accounts_ssh_authorized_keys_line_parser_string(str)
-    matched = str.match(%r{((ssh-|ecdsa-)[^\s]+)\s+([^\s]+)\s+(.*)$})
+    matched = str.match(%r{((sk-ecdsa-|ssh-|ecdsa-)[^\s]+)\s+([^\s]+)\s+(.*)$})
     raise ArgumentError, 'Wrong Keyline format!' unless matched && matched.length == 5
     options = str[0, str.index(matched[0])].rstrip
     [options, matched[1], matched[3], matched[4]]

--- a/metadata.json
+++ b/metadata.json
@@ -80,6 +80,6 @@
     }
   ],
   "template-url": "https://github.com/puppetlabs/pdk-templates.git#main",
-  "template-ref": "heads/main-0-ge04486b",
-  "pdk-version": "2.0.0"
+  "template-ref": "heads/main-0-g03daa92",
+  "pdk-version": "2.1.0"
 }

--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -5,6 +5,8 @@ require 'spec_helper_acceptance'
 test_key = 'AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8Hfd'\
            'OV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9W'\
            'hQ=='
+ecdsa_test_key = 'AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNlpEm6+RwCiQXgQAb0P1asEAxCJDVtm/YYyUbdSifCbri98fjs1C/03pm9yLRQ0W/S70S8AhDCMjVFA07WzjOQ='
+ecdsa_sk_test_key = 'AAAAInNrLWVjZHNhLXNoYTItbmlzdHAyNTZAb3BlbnNzaC5jb20AAAAIbmlzdHAyNTYAAABBBAjkGvdKC05udQc82xGWWSKHbmJyBoa/oCq+2FiU6udqQyx0uOEC3YZAjvygBSdIo5vCpDELqJxaNQGQEkeUyYYAAAAEc3NoOg=='
 
 pp_accounts_define = <<-PUPPETCODE
   file { '/test':
@@ -22,7 +24,9 @@ pp_accounts_define = <<-PUPPETCODE
     bash_profile_content => file('accounts/shell/bash_profile'),
     sshkeys              => [
       'ssh-rsa #{test_key} vagrant',
-      'command="/bin/echo Hello",from="myhost.example.com,192.168.1.1" ssh-rsa #{test_key} vagrant2'
+      'command="/bin/echo Hello",from="myhost.example.com,192.168.1.1" ssh-rsa #{test_key} vagrant2',
+      'ecdsa-sha2-nistp256 #{ecdsa_test_key} vagrant3',
+      'sk-ecdsa-sha2-nistp256@openssh.com #{ecdsa_sk_test_key} vagrant4'
     ],
   }
 PUPPETCODE
@@ -52,7 +56,9 @@ pp_with_managevim = <<-PUPPETCODE
     bash_profile_content => file('accounts/shell/bash_profile'),
     sshkeys              => [
       'ssh-rsa #{test_key} vagrant',
-      'from="myhost.example.com,192.168.1.1" ssh-rsa #{test_key} vagrant2'
+      'from="myhost.example.com,192.168.1.1" ssh-rsa #{test_key} vagrant2',
+      'ecdsa-sha2-nistp256 #{ecdsa_test_key} vagrant3',
+      'sk-ecdsa-sha2-nistp256@openssh.com #{ecdsa_sk_test_key} vagrant4'
     ],
   }
 PUPPETCODE

--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -20,7 +20,7 @@ pp_accounts_define = <<-PUPPETCODE
     ]
   }
   else {
-    $key_test = [      
+    $key_test = [#{'      '}
       'ssh-rsa #{test_key} vagrant',
       'command="/bin/echo Hello",from="myhost.example.com,192.168.1.1" ssh-rsa #{test_key} vagrant2',
       'ecdsa-sha2-nistp256 #{ecdsa_test_key} vagrant3',
@@ -62,7 +62,7 @@ pp_with_managevim = <<-PUPPETCODE
     ]
   }
   else {
-    $key_test = [      
+    $key_test = [#{'      '}
       'ssh-rsa #{test_key} vagrant',
       'command="/bin/echo Hello",from="myhost.example.com,192.168.1.1" ssh-rsa #{test_key} vagrant2',
       'ecdsa-sha2-nistp256 #{ecdsa_test_key} vagrant3',

--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -13,6 +13,21 @@ pp_accounts_define = <<-PUPPETCODE
     ensure => directory,
     before => Accounts::User['hunner'],
   }
+  if $facts['puppetversion'][0] == '6' {
+    $key_test = [
+      'ssh-rsa #{test_key} vagrant',
+      'command="/bin/echo Hello",from="myhost.example.com,192.168.1.1" ssh-rsa #{test_key} vagrant2'
+    ]
+  }
+  else {
+    $key_test = [      
+      'ssh-rsa #{test_key} vagrant',
+      'command="/bin/echo Hello",from="myhost.example.com,192.168.1.1" ssh-rsa #{test_key} vagrant2',
+      'ecdsa-sha2-nistp256 #{ecdsa_test_key} vagrant3',
+      'sk-ecdsa-sha2-nistp256@openssh.com #{ecdsa_sk_test_key} vagrant4'
+    ]
+  }
+
   accounts::user { 'hunner':
     groups               => ['root'],
     password             => 'hi',
@@ -22,12 +37,7 @@ pp_accounts_define = <<-PUPPETCODE
     managevim            => false,
     bashrc_content       => file('accounts/shell/bashrc'),
     bash_profile_content => file('accounts/shell/bash_profile'),
-    sshkeys              => [
-      'ssh-rsa #{test_key} vagrant',
-      'command="/bin/echo Hello",from="myhost.example.com,192.168.1.1" ssh-rsa #{test_key} vagrant2',
-      'ecdsa-sha2-nistp256 #{ecdsa_test_key} vagrant3',
-      'sk-ecdsa-sha2-nistp256@openssh.com #{ecdsa_sk_test_key} vagrant4'
-    ],
+    sshkeys              => $key_test,
   }
 PUPPETCODE
 
@@ -45,6 +55,21 @@ pp_with_managevim = <<-PUPPETCODE
     ensure => directory,
     before => Accounts::User['hunner'],
   }
+  if $facts['puppetversion'][0] == '6' {
+    $key_test = [
+      'ssh-rsa #{test_key} vagrant',
+      'command="/bin/echo Hello",from="myhost.example.com,192.168.1.1" ssh-rsa #{test_key} vagrant2'
+    ]
+  }
+  else {
+    $key_test = [      
+      'ssh-rsa #{test_key} vagrant',
+      'command="/bin/echo Hello",from="myhost.example.com,192.168.1.1" ssh-rsa #{test_key} vagrant2',
+      'ecdsa-sha2-nistp256 #{ecdsa_test_key} vagrant3',
+      'sk-ecdsa-sha2-nistp256@openssh.com #{ecdsa_sk_test_key} vagrant4'
+    ]
+  }
+
   accounts::user { 'hunner':
     groups               => ['root'],
     password             => 'hi',
@@ -54,12 +79,7 @@ pp_with_managevim = <<-PUPPETCODE
     managevim            => true,
     bashrc_content       => file('accounts/shell/bashrc'),
     bash_profile_content => file('accounts/shell/bash_profile'),
-    sshkeys              => [
-      'ssh-rsa #{test_key} vagrant',
-      'from="myhost.example.com,192.168.1.1" ssh-rsa #{test_key} vagrant2',
-      'ecdsa-sha2-nistp256 #{ecdsa_test_key} vagrant3',
-      'sk-ecdsa-sha2-nistp256@openssh.com #{ecdsa_sk_test_key} vagrant4'
-    ],
+    sshkeys              => $key_test,
   }
 PUPPETCODE
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,6 +48,18 @@ RSpec.configure do |c|
   c.after(:suite) do
     RSpec::Puppet::Coverage.report!(0)
   end
+
+  # Filter backtrace noise
+  backtrace_exclusion_patterns = [
+    %r{spec_helper},
+    %r{gems},
+  ]
+
+  if c.respond_to?(:backtrace_exclusion_patterns)
+    c.backtrace_exclusion_patterns = backtrace_exclusion_patterns
+  elsif c.respond_to?(:backtrace_clean_patterns)
+    c.backtrace_clean_patterns = backtrace_exclusion_patterns
+  end
 end
 
 # Ensures that a module is defined


### PR DESCRIPTION
CHANGE:
 * Adds `sk-ecdsa-` as a valid prefix for SSH public keys fixing support for those key types
ADD:
 * Adds `sk-ecdsa-` and `ecdsa` Key tests
 
 This implements new key types available in OpenSSH 8.2+