### PR TITLE
pdksync - (IAC-1598) - Remove Support for Debian 8

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -47,7 +47,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "8",
         "9",
         "10",
         "11"


### PR DESCRIPTION
(IAC-1598) - Remove Support for Debian 8
pdk version: `2.1.0` 
