### PR TITLE
pdksync - (IAC-1787) Remove Support for CentOS 6

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -25,7 +25,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]


### PR DESCRIPTION
(IAC-1787) Remove Support for CentOS 6
pdk version: `2.1.0` 
