### PR TITLE
Revert "pdksync - (GH-cat-8) Move CentOS 8 support to CentOS Stream 8"

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -25,8 +25,8 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "Stream8",
-        "7"
+        "7",
+        "8"
       ]
     },
     {


### PR DESCRIPTION
Upon further discussion and with input from the community, has been decided that this is not truly necessary as with the original CentOS 8 being shuttered and declared EOL there is no real ambiguity between what version is meant. In addition Puppet Facter does not see a difference between the two and so no distinction seems to be needed from a maintanence perspective.