### PR TITLE
Removing support for Centos 8

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -26,8 +26,7 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7",
-        "8"
+        "7"
       ]
     },
     {


### PR DESCRIPTION
Refactoring metadata.json to reflect supported OSs.

https://puppet.com/docs/pe/2021.7/supported_operating_systems.html