### PR TITLE
CONT-1219 : Adding label enforcements for members of puppetlabs org

### DIFF
--- a/.github/workflows/labeller.yml
+++ b/.github/workflows/labeller.yml
@@ -1,22 +1,50 @@
 name: community-labeller
 
 on:
-  issues:
+  pull_request:
     types:
       - opened
-  pull_request_target:
-    types:
-      - opened
+      - labeled
+      - unlabeled
 
 jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-
-      - uses: puppetlabs/community-labeller@v0
-        name: Label issues or pull requests
+      - name: Label issues or pull requests
+        uses: puppetlabs/community-labeller@v0
         with:
           label_name: community
           label_color: '5319e7'
           org_membership: puppetlabs
           token: ${{ secrets.IAC_COMMUNITY_LABELER }}
+
+  test:
+    name: Label Must Exist
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for Labels
+        uses: actions/github-script@v6
+        with:
+          script: |
+            async function getPullRequest() {
+              // Get current pull request labels
+              const { data: { labels } } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.number,
+              });
+
+              // Log found label names
+              for (const label of labels) {
+                core.info(`Found label named '${label.name}' on pull request number ${context.payload.number}`);
+              }
+
+              // Fail workflow if no labels exist
+              const labelsExist = labels.length > 0;
+              if (!labelsExist) {
+                core.setFailed(`Please ensure that a label exists on pull request number ${context.payload.number}`);
+              }
+            }
+
+            await getPullRequest();


### PR DESCRIPTION
## Summary
Adding label enforcements for members of puppetlabs org.

## Additional Context
Add any additional context about the problem here. 
- [ ] ci should fail when label is not present on PR.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)
