### PR TITLE
(CAT-1269) - CI Fixes

### DIFF
--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -13,20 +13,13 @@ pp_accounts_define = <<-PUPPETCODE
     ensure => directory,
     before => Accounts::User['hunner'],
   }
-  if $facts['puppetversion'][0] == '6' {
-    $key_test = [
-      'ssh-rsa #{test_key} vagrant',
-      'command="/bin/echo Hello",from="myhost.example.com,192.168.1.1" ssh-rsa #{test_key} vagrant2'
-    ]
-  }
-  else {
-    $key_test = [#{'      '}
-      'ssh-rsa #{test_key} vagrant',
-      'command="/bin/echo Hello",from="myhost.example.com,192.168.1.1" ssh-rsa #{test_key} vagrant2',
-      'ecdsa-sha2-nistp256 #{ecdsa_test_key} vagrant3',
-      'sk-ecdsa-sha2-nistp256@openssh.com #{ecdsa_sk_test_key} vagrant4'
-    ]
-  }
+
+  $key_test = [#{'      '}
+    'ssh-rsa #{test_key} vagrant',
+    'command="/bin/echo Hello",from="myhost.example.com,192.168.1.1" ssh-rsa #{test_key} vagrant2',
+    'ecdsa-sha2-nistp256 #{ecdsa_test_key} vagrant3',
+    'sk-ecdsa-sha2-nistp256@openssh.com #{ecdsa_sk_test_key} vagrant4'
+  ]
 
   accounts::user { 'hunner':
     groups               => ['root'],
@@ -55,20 +48,13 @@ pp_with_managevim = <<-PUPPETCODE
     ensure => directory,
     before => Accounts::User['hunner'],
   }
-  if $facts['puppetversion'][0] == '6' {
-    $key_test = [
-      'ssh-rsa #{test_key} vagrant',
-      'command="/bin/echo Hello",from="myhost.example.com,192.168.1.1" ssh-rsa #{test_key} vagrant2'
-    ]
-  }
-  else {
-    $key_test = [#{'      '}
-      'ssh-rsa #{test_key} vagrant',
-      'command="/bin/echo Hello",from="myhost.example.com,192.168.1.1" ssh-rsa #{test_key} vagrant2',
-      'ecdsa-sha2-nistp256 #{ecdsa_test_key} vagrant3',
-      'sk-ecdsa-sha2-nistp256@openssh.com #{ecdsa_sk_test_key} vagrant4'
-    ]
-  }
+
+  $key_test = [#{'      '}
+    'ssh-rsa #{test_key} vagrant',
+    'command="/bin/echo Hello",from="myhost.example.com,192.168.1.1" ssh-rsa #{test_key} vagrant2',
+    'ecdsa-sha2-nistp256 #{ecdsa_test_key} vagrant3',
+    'sk-ecdsa-sha2-nistp256@openssh.com #{ecdsa_sk_test_key} vagrant4'
+  ]
 
   accounts::user { 'hunner':
     groups               => ['root'],

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -93,7 +93,7 @@ end
 def clear_temp_hieradata
   if @temp_hieradata_dirs && !@temp_hieradata_dirs.empty?
     @temp_hieradata_dirs.each do |data_dir|
-      if File.exists?(data_dir)
+      if File.exist?(data_dir)
         FileUtils.rm_r(data_dir)
       end
     end
@@ -102,6 +102,9 @@ end
 
 RSpec.configure do |c|
   c.before(:all) do
+    # Set sticky bit for docker provisioner
+    run_shell('chmod +t /tmp/') if ENV['TARGET_HOST'].match(/^localhost:/)
+
     @temp_hieradata_dirs = @temp_hieradata_dirs || []
     @hiera_datadir = hiera_datadir
   end


### PR DESCRIPTION
## Summary

The CI for containers getting failing from last couple of days due to missing sticky bit for `/tmp` directory. Setting sticky bit for `/tmp` shared directory.

## Additional Context
- N/A

## Related Issues (if any)
- N/A

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)
