### PR TITLE
Change password max age parameter lower bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Allows strings up to 32 characters long that begin with a lower case letter or u
 
 #### `Accounts::User::PasswordMaxAge`
 
-Maximum number of days a password may be used before it must be changed. Allows any integer from `0` to `99999`. See [`user`](https://puppet.com/docs/puppet/latest/types/user.html#user-attribute-password_max_age) resource.
+Maximum number of days a password may be used before it must be changed. Allows any integer from `-1` to `99999`. See [`user`](https://puppet.com/docs/puppet/latest/types/user.html#user-attribute-password_max_age) resource.
 
 #### `Accounts::User::Resource`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -428,7 +428,7 @@ Default value: `'!!'`
 Data type: `Optional[Accounts::User::PasswordMaxAge]`
 
 Maximum number of days a password may be used before it must be changed.
-Allows any integer from `0` to `99999`. See the
+Allows any integer from `-1` to `99999`. See the
 [`user`](https://puppet.com/docs/puppet/latest/types/user.html#user-attribute-password_max_age)
 resource.
 

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -126,7 +126,7 @@
 #
 # @param password_max_age
 #   Maximum number of days a password may be used before it must be changed.
-#   Allows any integer from `0` to `99999`. See the
+#   Allows any integer from `-1` to `99999`. See the
 #   [`user`](https://puppet.com/docs/puppet/latest/types/user.html#user-attribute-password_max_age)
 #   resource.
 #

--- a/types/user/passwordmaxage.pp
+++ b/types/user/passwordmaxage.pp
@@ -3,4 +3,4 @@
 # On most systems, the default value of 99999 is about 274 years, which
 # effectively disables password aging.
 #
-type Accounts::User::PasswordMaxAge = Integer[1, 99999]
+type Accounts::User::PasswordMaxAge = Integer[-1, 99999]


### PR DESCRIPTION
## Summary
Allow disabling of password expiration by changing lower bounds of password_max_age parameter to negative one.

## Additional Context
On Linux, the password age check can be disabled by setting the parameter to negative one via:
`  chage -M -1 <user>
`
