### PR TITLE
(CAT-1746) - Fixing CI pipeline

### DIFF
--- a/types/user/resource.pp
+++ b/types/user/resource.pp
@@ -27,7 +27,6 @@ type Accounts::User::Resource = Struct[
     Optional[managehome]               => Boolean,
     Optional[managevim]                => Boolean,
     Optional[membership]               => Enum['inclusive','minimum'],
-    Optional[name]                     => Accounts::User::Name,
     Optional[password]                 => String,
     Optional[password_max_age]         => Accounts::User::PasswordMaxAge,
     Optional[purge_sshkeys]            => Boolean,


### PR DESCRIPTION
## Summary

Fixing the rubocop syntax warning for duplication of name param.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)
