### PR TITLE
Add bastelfreak to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
 # Setting ownership to the modules team
-* @puppetlabs/modules
+# include Trusted Contributors
+* @puppetlabs/modules @bastelfreak


### PR DESCRIPTION
I'm in the trusted contributors group but somehow the CODEOWNERS change was missing.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)
