### PR TITLE
usermanagement: prohibit empty ssh keys

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -505,7 +505,7 @@ Default value: `'0600'`
 
 ##### <a name="-accounts--user--sshkeys"></a>`sshkeys`
 
-Data type: `Array[String]`
+Data type: `Array[String[1]]`
 
 An array of SSH public keys associated with the user. These should be
 complete public key strings that include the type, content and name of the
@@ -559,7 +559,7 @@ The returned options element can by an empty string.
 accounts_ssh_authorized_keys_line_parser_string('options ssh-rsa AAAA... comment)
 ```
 
-#### `accounts_ssh_authorized_keys_line_parser(String $str)`
+#### `accounts_ssh_authorized_keys_line_parser(String[1] $str)`
 
 Parse an ssh authorized_keys line string into an array using its expected
 pattern by using a combination of regex matching and extracting the substring
@@ -580,7 +580,7 @@ accounts_ssh_authorized_keys_line_parser_string('options ssh-rsa AAAA... comment
 
 ##### `str`
 
-Data type: `String`
+Data type: `String[1]`
 
 ssh authorized_keys line string
 

--- a/lib/puppet/functions/accounts_ssh_authorized_keys_line_parser.rb
+++ b/lib/puppet/functions/accounts_ssh_authorized_keys_line_parser.rb
@@ -12,7 +12,7 @@ Puppet::Functions.create_function(:accounts_ssh_authorized_keys_line_parser) do
   # @example Calling the function
   #   accounts_ssh_authorized_keys_line_parser_string('options ssh-rsa AAAA... comment)
   dispatch :accounts_ssh_authorized_keys_line_parser_string do
-    param 'String', :str
+    param 'String[1]', :str
   end
 
   def accounts_ssh_authorized_keys_line_parser_string(str)

--- a/manifests/key_management.pp
+++ b/manifests/key_management.pp
@@ -42,7 +42,7 @@ define accounts::key_management (
   Accounts::User::Name           $sshkey_group       = $group,
   Accounts::User::Name           $sshkey_owner       = $user,
   Variant[Integer[0],String]     $sshkey_mode        = '0600',
-  Array[String]                  $sshkeys            = [],
+  Array[String[1]]               $sshkeys            = [],
   Optional[Stdlib::Unixpath]     $user_home          = undef,
 ) {
   if $user_home {
@@ -98,7 +98,7 @@ define accounts::key_management (
   }
 
   if $sshkeys != [] {
-    $sshkeys.each |$sshkey| {
+    $sshkeys.each |String[1] $sshkey| {
       accounts::manage_keys { "${sshkey} for ${user}":
         ensure    => $ensure,
         keyspec   => $sshkey,

--- a/manifests/manage_keys.pp
+++ b/manifests/manage_keys.pp
@@ -20,7 +20,7 @@
 #
 define accounts::manage_keys (
   Stdlib::Unixpath         $key_file,
-  String                   $keyspec,
+  String[1]                $keyspec,
   Accounts::User::Name     $user,
   Enum['absent','present'] $ensure    = 'present',
   Accounts::User::Name     $key_owner = $user,

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -213,7 +213,7 @@ define accounts::user (
   Optional[Accounts::User::Name]           $sshkey_group             = $group,
   Optional[Accounts::User::Name]           $sshkey_owner             = $name,
   Variant[Integer[0],String]               $sshkey_mode              = '0600',
-  Array[String]                            $sshkeys                  = [],
+  Array[String[1]]                         $sshkeys                  = [],
   Boolean                                  $system                   = false,
   Optional[Accounts::User::Uid]            $uid                      = undef,
 ) {

--- a/spec/functions/accounts_ssh_authorized_keys_line_parser_spec.rb
+++ b/spec/functions/accounts_ssh_authorized_keys_line_parser_spec.rb
@@ -8,7 +8,7 @@ describe 'accounts_ssh_authorized_keys_line_parser' do
   }
 
   it {
-    expect(subject).to run.with_params('').and_raise_error(ArgumentError, %r{Wrong Keyline format!})
+    expect(subject).to run.with_params('').and_raise_error(ArgumentError, %r{'accounts_ssh_authorized_keys_line_parser' parameter 'str' expects a String\[1\] value, got String})
   }
 
   it {


### PR DESCRIPTION
previously we allowed ssh keys as empty strings `''`. This doesn't make sense and breaks the `accounts_ssh_authorized_keys_line_parser()` function.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)
