### PR TITLE
accounts_ssh_authorized_keys_line_parser: Output regex matches when sshkey format isnt correct

### DIFF
--- a/lib/puppet/functions/accounts_ssh_authorized_keys_line_parser.rb
+++ b/lib/puppet/functions/accounts_ssh_authorized_keys_line_parser.rb
@@ -17,7 +17,16 @@ Puppet::Functions.create_function(:accounts_ssh_authorized_keys_line_parser) do
 
   def accounts_ssh_authorized_keys_line_parser_string(str)
     matched = str.match(%r{((sk-ssh-ed25519|sk-ecdsa-|ssh-|ecdsa-)[^\s]+)\s+([^\s]+)\s+(.*)$})
-    raise ArgumentError, 'Wrong Keyline format!' unless matched && matched.length == 5
+
+    raise ArgumentError, "Wrong Keyline format! Got nil after applying regex to'#{str}'" unless matched
+    unless matched.length == 5
+      output = []
+      # first element is str, aftwerwards are all matching groups. We ignore the first element
+      (1..matched.length).each do |counter|
+        output << "element #{counter}: #{matched[counter]}"
+      end
+      raise ArgumentError, "Wrong Keyline format! Input: #{str}. Expected 4 elements after applying regex, got: #{output}"
+    end
 
     options = str[0, str.index(matched[0])].rstrip
     [options, matched[1], matched[3], matched[4]]


### PR DESCRIPTION
This makes debugging a lot easier when the key format is wrong.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)
