### PR TITLE
(CAT-2296) Update github runner image to ubuntu-24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,4 @@ jobs:
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     secrets: "inherit"
     with:
-      runs_on: "ubuntu-20.04"
+      runs_on: "ubuntu-24.04"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,4 +15,4 @@ jobs:
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     secrets: "inherit"
     with:
-      runs_on: "ubuntu-20.04"
+      runs_on: "ubuntu-24.04"


### PR DESCRIPTION
ubuntu-20.04 is not supported anymore: https://github.com/actions/runner-images/issues/11101

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)
