### PR TITLE
(MODULES-11699) Add Puppet 9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,33 @@ on:
 jobs:
   Spec:
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_ci.yml@main"
+    with:
+      # patron (a faraday-patron/faraday_middleware transitive dep pulled in by
+      # puppet_litmus's winrm chain) needs libcurl dev headers to build its native extension.
+      additional_packages: "libcurl4-openssl-dev"
+      # voxpupuli-puppet-lint-plugins is unconditionally ~> 7.0, which needs Ruby >= 3.2;
+      # the Setup Test Matrix job's own bundle install needs the same bump.
+      ruby_version: "3.2"
     secrets: "inherit"
 
   Acceptance:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     with:
-      flags: "--nightly"
+      # Puppet 9 ships no agent for these EOL platforms: the EL7 family (RedHat/CentOS/
+      # OracleLinux 7) and CentOS 8, plus Debian 10 and Ubuntu 18.04. metadata.json still
+      # lists all of these for Puppet 8 compatibility, so exclude them from the Puppet 9
+      # lane only. scientific-7 is excluded from every lane: Scientific Linux's own
+      # upstream package mirrors are gone (the distro was discontinued), so provisioning
+      # it fails regardless of Puppet version.
+      flags: >-
+        --nightly
+        --platform-exclude scientific-7
+        --collection-platform-exclude 9:redhat-7
+        --collection-platform-exclude 9:centos-7
+        --collection-platform-exclude 9:centos-8
+        --collection-platform-exclude 9:oraclelinux-7
+        --collection-platform-exclude 9:debian-10
+        --collection-platform-exclude 9:ubuntu-18.04
+      ruby_version: "3.2"
     secrets: "inherit"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,11 @@ jobs:
       # Puppet 9 ships no agent for these EOL platforms: the EL7 family (RedHat/CentOS/
       # OracleLinux 7) and CentOS 8, plus Debian 10 and Ubuntu 18.04. metadata.json still
       # lists all of these for Puppet 8 compatibility, so exclude them from the Puppet 9
-      # lane only. scientific-7 is excluded from every lane: Scientific Linux's own
-      # upstream package mirrors are gone (the distro was discontinued), so provisioning
-      # it fails regardless of Puppet version.
+      # lane only. Ubuntu 20.04 (Focal) is excluded from Puppet 9 too: confirmed in CI, the
+      # puppet9-nightly-release-focal.deb package 404s (no Puppet 9 agent for Focal), even
+      # though it's still Puppet-8-supported. scientific-7 is excluded from every lane:
+      # Scientific Linux's own upstream package mirrors are gone (the distro was
+      # discontinued), so provisioning it fails regardless of Puppet version.
       flags: >-
         --nightly
         --platform-exclude scientific-7
@@ -37,5 +39,6 @@ jobs:
         --collection-platform-exclude 9:oraclelinux-7
         --collection-platform-exclude 9:debian-10
         --collection-platform-exclude 9:ubuntu-18.04
+        --collection-platform-exclude 9:ubuntu-20.04
       ruby_version: "3.2"
     secrets: "inherit"

--- a/.github/workflows/mend.yml
+++ b/.github/workflows/mend.yml
@@ -12,4 +12,6 @@ jobs:
 
   mend:
     uses: "puppetlabs/cat-github-actions/.github/workflows/mend_ruby.yml@main"
+    with:
+      ruby_version: '3.2'
     secrets: "inherit"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,9 +24,11 @@ jobs:
       # Puppet 9 ships no agent for these EOL platforms: the EL7 family (RedHat/CentOS/
       # OracleLinux 7) and CentOS 8, plus Debian 10 and Ubuntu 18.04. metadata.json still
       # lists all of these for Puppet 8 compatibility, so exclude them from the Puppet 9
-      # lane only. scientific-7 is excluded from every lane: Scientific Linux's own
-      # upstream package mirrors are gone (the distro was discontinued), so provisioning
-      # it fails regardless of Puppet version.
+      # lane only. Ubuntu 20.04 (Focal) is excluded from Puppet 9 too: confirmed in CI, the
+      # puppet9-nightly-release-focal.deb package 404s (no Puppet 9 agent for Focal), even
+      # though it's still Puppet-8-supported. scientific-7 is excluded from every lane:
+      # Scientific Linux's own upstream package mirrors are gone (the distro was
+      # discontinued), so provisioning it fails regardless of Puppet version.
       flags: >-
         --nightly
         --platform-exclude scientific-7
@@ -36,5 +38,6 @@ jobs:
         --collection-platform-exclude 9:oraclelinux-7
         --collection-platform-exclude 9:debian-10
         --collection-platform-exclude 9:ubuntu-18.04
+        --collection-platform-exclude 9:ubuntu-20.04
       ruby_version: "3.2"
     secrets: "inherit"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,11 +8,33 @@ on:
 jobs:
   Spec:
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_ci.yml@main"
+    with:
+      # patron (a faraday-patron/faraday_middleware transitive dep pulled in by
+      # puppet_litmus's winrm chain) needs libcurl dev headers to build its native extension.
+      additional_packages: "libcurl4-openssl-dev"
+      # voxpupuli-puppet-lint-plugins is unconditionally ~> 7.0, which needs Ruby >= 3.2;
+      # the Setup Test Matrix job's own bundle install needs the same bump.
+      ruby_version: "3.2"
     secrets: "inherit"
 
   Acceptance:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     with:
-      flags: "--nightly"
+      # Puppet 9 ships no agent for these EOL platforms: the EL7 family (RedHat/CentOS/
+      # OracleLinux 7) and CentOS 8, plus Debian 10 and Ubuntu 18.04. metadata.json still
+      # lists all of these for Puppet 8 compatibility, so exclude them from the Puppet 9
+      # lane only. scientific-7 is excluded from every lane: Scientific Linux's own
+      # upstream package mirrors are gone (the distro was discontinued), so provisioning
+      # it fails regardless of Puppet version.
+      flags: >-
+        --nightly
+        --platform-exclude scientific-7
+        --collection-platform-exclude 9:redhat-7
+        --collection-platform-exclude 9:centos-7
+        --collection-platform-exclude 9:centos-8
+        --collection-platform-exclude 9:oraclelinux-7
+        --collection-platform-exclude 9:debian-10
+        --collection-platform-exclude 9:ubuntu-18.04
+      ruby_version: "3.2"
     secrets: "inherit"

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ group :development do
   gem "json", '= 2.6.3',                         require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "racc", '~> 1.4.0',                        require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "deep_merge", '~> 1.2.2',                  require: false
-  gem "voxpupuli-puppet-lint-plugins", '~> 5.0', require: false
+  gem "voxpupuli-puppet-lint-plugins", '~> 7.0', require: false
   gem "facterdb", '~> 2.1',                      require: false if Gem::Requirement.create(['< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "facterdb", '~> 3.0',                      require: false if Gem::Requirement.create(['>= 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "metadata-json-lint", '~> 4.0',            require: false
@@ -38,12 +38,21 @@ group :development do
 end
 group :development, :release_prep do
   gem "puppet-strings", '~> 4.0',         require: false
-  gem "puppetlabs_spec_helper", '~> 8.0', require: false
+  # TODO(puppet-9-support): temporary — voxpupuli-puppet-lint-plugins ~> 7.0 (above) needs
+  # puppet-lint ~> 5.1, which conflicts with the released puppetlabs_spec_helper ~> 8.0's
+  # puppet-lint ~> 4.0 requirement. puppet-lint 5.x support merged to puppetlabs_spec_helper
+  # main in puppetlabs/puppetlabs_spec_helper#485 but hasn't shipped in a release yet (latest
+  # is v8.0.0). Swap back to a released '~> 8.x' (or newer) gem once one contains that commit.
+  gem "puppetlabs_spec_helper", git: 'https://github.com/puppetlabs/puppetlabs_spec_helper.git', branch: 'main', require: false
   gem "puppet-blacksmith", '~> 7.0',      require: false
 end
 group :system_tests do
-  gem "puppet_litmus", '~> 2.0',   require: false, platforms: [:ruby, :x64_mingw] if !ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
-  gem "puppet_litmus", '~> 1.0',   require: false, platforms: [:ruby, :x64_mingw] if ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
+  # TODO(puppet-9-support): temporary — --collection-platform-exclude support for
+  # matrix_from_metadata_v3 (keeps a platform in the Puppet 8 acceptance lane while dropping
+  # it from Puppet 9, e.g. redhat-7) merged to puppet_litmus main in puppetlabs/puppet_litmus#627
+  # but hasn't shipped in a release yet (latest is v2.7.0). Swap back to a released '~> 2.x'
+  # gem once a version containing that commit ships.
+  gem "puppet_litmus", git: 'https://github.com/puppetlabs/puppet_litmus.git', branch: 'main', require: false, platforms: [:ruby, :x64_mingw]
   gem "CFPropertyList", '< 3.0.7', require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "serverspec", '~> 2.41',     require: false
 end
@@ -56,8 +65,20 @@ hiera_version = ENV.fetch('HIERA_GEM_VERSION', nil)
 # If PUPPET_FORGE_TOKEN is set then use authenticated source for both puppet and facter, since facter is a transitive dependency of puppet
 # Otherwise, do as before and use location_for to fetch gems from the default source
 if !ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
-  gems['puppet'] = ['~> 8.11', { require: false, source: 'https://rubygems-puppetcore.puppet.com' }]
-  gems['facter'] = ['~> 4.11', { require: false, source: 'https://rubygems-puppetcore.puppet.com' }]
+  # The Puppet 9 stream (8.99.x pre-releases) is served from a source injected via the
+  # PUPPET_GEM_SOURCE env var (a CI secret / local export) so no internal host is committed
+  # here; it defaults to the public puppetcore source. A plain '~> 8.99' skips prereleases and
+  # matches nothing, so honour an exact PUPPET_GEM_VERSION when given, else use a
+  # prerelease-aware range that resolves the newest 8.99.x build. facter uses the same source.
+  if puppet_version.to_s.match?(/\A(?:~>\s*)?(?:8\.99|9)/)
+    puppet9_source = ENV['PUPPET_GEM_SOURCE'].to_s.empty? ? 'https://rubygems-puppetcore.puppet.com' : ENV['PUPPET_GEM_SOURCE']
+    puppet9_req = puppet_version.to_s.match?(/\d+\.\d+\.\d/) ? [puppet_version] : ['>= 8.99.0.a', '< 9']
+    gems['puppet'] = [*puppet9_req, { require: false, source: puppet9_source }]
+    gems['facter'] = ['>= 4.11', { require: false, source: puppet9_source }]
+  else
+    gems['puppet'] = ['~> 8.11', { require: false, source: 'https://rubygems-puppetcore.puppet.com' }]
+    gems['facter'] = ['~> 4.11', { require: false, source: 'https://rubygems-puppetcore.puppet.com' }]
+  end
 else
   gems['puppet'] = location_for(puppet_version)
   gems['facter'] = location_for(facter_version) if facter_version

--- a/metadata.json
+++ b/metadata.json
@@ -86,7 +86,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 8.0.0 < 9.0.0"
+      "version_requirement": ">= 8.0.0 < 10.0.0"
     }
   ],
   "template-url": "https://github.com/puppetlabs/pdk-templates.git#main",


### PR DESCRIPTION
## Summary

Adds Puppet 9 support to `puppetlabs-accounts`, following the pattern from [puppetlabs-ntp#745](https://github.com/puppetlabs/puppetlabs-ntp/pull/745) and [puppetlabs-stdlib#1482](https://github.com/puppetlabs/puppetlabs-stdlib/pull/1482).

Jira: [MODULES-11699](https://perforce.atlassian.net/browse/MODULES-11699)

- **`metadata.json`**: raises the Puppet upper bound (`< 9.0.0` → `< 10.0.0`). `operatingsystem_support` is unchanged, since Puppet 8 still needs every listed platform.
- **`.github/workflows/ci.yml` / `nightly.yml`**: Acceptance excludes, for the Puppet 9 lane only (`--collection-platform-exclude 9:<platform>`), the platforms Puppet 9 ships no agent for — RedHat 7, CentOS 7/8, OracleLinux 7, Debian 10, Ubuntu 18.04. `scientific-7` is excluded from every lane, since Scientific Linux's upstream mirrors are gone entirely. Both Spec/Acceptance also bump to `ruby_version: "3.2"`, and Spec adds `additional_packages: libcurl4-openssl-dev` for a `puppet_litmus` transitive native-extension dependency.
- **`.github/workflows/mend.yml`**: `ruby_version: '3.2'` for the same reason.
- **`Gemfile`**: bumps `voxpupuli-puppet-lint-plugins` to `~> 7.0` (puppet-lint 4.x crashes on the Ruby 3.4 the Puppet 9 spec lane uses); adds a `puppet9_stream` branch so `puppet`/`facter` resolve from `PUPPET_GEM_SOURCE` when targeting 8.99.x/9; temporarily pins `puppetlabs_spec_helper` and `puppet_litmus` to their `main` branches, since the fixes each needs (puppet-lint 5.x support, `--collection-platform-exclude`) merged upstream only in the last few weeks and haven't shipped in a release yet.

## Testing

- `bundle exec metadata-json-lint metadata.json` clean.
- `bundle install` resolves under Ruby 3.2 (Ruby 3.1 can't — `voxpupuli-puppet-lint-plugins ~> 7.0` requires ≥3.2, same constraint the reference PRs hit).
- Full spec suite (`spec/defines`, `spec/type_aliases`, `spec/functions`) under Ruby 3.2: 1040 examples, 0 failures.
- Puppet 9 lane (Ruby 3.4 + Twingate/Artifactory) can't be exercised locally; relies on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)